### PR TITLE
Fetch user journey events from Splunk

### DIFF
--- a/scripts/fetch-uj-records.sh
+++ b/scripts/fetch-uj-records.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# fetch-uj-records.sh
+#   Fetch user journey records from Splunk
+#   Records look almost like Segment track records but some further adjustments
+#   are required such as:
+#   - Converting nested JSON objects from strings to objects
+#   - Mapping cluster usernames to SSO user IDs
+#   This script assumes that credentials are preconfigured for curl for
+#   connecting to Splunk in a .netrc file
+#
+set -o pipefail -o errexit -o nounset
+
+SPLUNK_API_URL=https://splunk-api.corp.redhat.com:8089
+SPLUNK_APP_NAME=rh_rhtap
+SPLUNK_APP_API_URL="$SPLUNK_API_URL/servicesNS/nobody/$SPLUNK_APP_NAME"
+SPLUNK_APP_SEARCH_URL="$SPLUNK_APP_API_URL/search/v2/jobs/export"
+
+FIELDS=(
+  auditID impersonatedUser.username objectRef.resource objectRef.namespace
+  objectRef.apiGroup objectRef.apiVersion objectRef.name verb
+  requestReceivedTimestamp
+)
+INDEX="federated:rh_rhtap_stage_audit" 
+SSO_LOOKUP="rhtap_staging_lookup"
+
+SQ_EV_SELECTOR='search 
+  index="'"$INDEX"'"
+  log_type=audit 
+  NOT verb IN (get, watch, list, deletecollection) 
+  "objectRef.apiGroup" IN ("toolchain.dev.openshift.com", "appstudio.redhat.com", "tekton.dev")
+  "impersonatedUser.username"="*"
+  '
+SQ_DEDUP_FIELDS="eval dummy=0$(for F in "${FIELDS[@]}"; do echo -n ",$F=mvindex('$F', 0)"; done)"
+SQ_GEN_JSON="eval
+  messageId=auditID,
+  timestamp=requestReceivedTimestamp,
+  type=\"track\",
+  userId='impersonatedUser.username',
+  event_verb=verb,
+  event_subject='objectRef.resource',
+  properties=json_object(
+    \"apiGroup\", 'objectRef.apiGroup',
+    \"apiVersion\", 'objectRef.apiVersion',
+    \"kind\", 'objectRef.resource',
+    \"namespace\", 'objectRef.namespace',
+    \"name\", 'objectRef.name'
+  )
+  | fields messageId, timestamp, type, userId, event_verb, event_subject, properties | fields - _*
+"
+
+QUERY="$SQ_EV_SELECTOR | $SQ_DEDUP_FIELDS | $SQ_GEN_JSON"
+
+set -o xtrace
+curl -k -n \
+    "$SPLUNK_APP_SEARCH_URL" \
+    -d output_mode=json \
+    -d search="$QUERY"

--- a/scripts/get-uid-map.sh
+++ b/scripts/get-uid-map.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# get-uid-map.sh
+#   Read UserSignup resources and generate a JSON object mapping from cluster
+#   usernames to SSO UDIs.
+#   This script assumes `oc` is preconfigured to connect to the right cluster
+#   and could be found in $PATH
+#
+set -o pipefail -o errexit -o nounset
+
+oc get \
+  -n toolchain-host-operator \
+  UserSignup \
+  -o=go-template \
+  --template=$'{ 
+    {{- $comma := false}}
+    {{- range .items}}
+      {{- if $uid := (index .metadata.annotations "toolchain.dev.openshift.com/sso-user-id")}}
+        {{- if $comma}},{{end}}
+        {{- $comma = true -}}
+        "{{.status.compliantUsername}}":{{$uid}}
+      {{- end}}
+    {{- end}}}\n' 

--- a/scripts/splunk-to-segment.sh
+++ b/scripts/splunk-to-segment.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# splunk-to-segment.sh
+#   Adapt user journey recordes loaded from Splunk for uploading into Segmment:
+#   - Map cluster usernames to SSO user IDs
+#   - Convert nested JSON objects from strings to actual objects.
+#   - Combine the event_* fields into a single UI-flavoured event string.
+#
+set -o pipefail -o errexit -o nounset
+
+# Add script file directory to PATH so we can use other scripts in the same
+# directory
+SELFDIR="$(dirname "$0")"
+PATH="$SELFDIR:${PATH#$SELFDIR:}"
+
+function event_verb_map() {
+  # Print a JSON map for converting preset tense K8s API server verbs to past
+  # tense
+  echo '{
+    "create": "created",
+    "delete": "deleted",
+    "deletecollection": "collection deleted",
+    "get": "fetched",
+    "head": "headers fetched",
+    "list": "listed",
+    "patch": "patched",
+    "update": "updated",
+    "watch": "watch started"
+  }'
+}
+
+function event_subject_map() {
+  # Print a JSON map for converting the plural resource names found in the
+  # audit log to the singular, capitalized names users are used to seeing
+  echo '{
+    "applications": "Application",
+    "bannedusers": "BannedUser",
+    "buildpipelineselectors": "BuildPipelineSelector",
+    "componentdetectionqueries": "ComponentDetectionQuery",
+    "components": "Component",
+    "customruns": "CustomRun",
+    "deploymenttargetclaims": "DeploymentTargetClaim",
+    "deploymenttargets": "DeploymentTarget",
+    "enterprisecontractpolicies": "EnterpriseContractPolicy",
+    "environments": "Environment",
+    "integrationtestscenarios": "IntegrationTestScenario",
+    "internalrequests": "InternalRequest",
+    "masteruserrecords": "MasterUserRecord",
+    "memberoperatorconfigs": "MemberOperatorConfig",
+    "memberstatuses": "MemberStatus",
+    "notifications": "Notification",
+    "nstemplatesets": "NSTemplateSet",
+    "nstemplatetiers": "NSTemplateTier",
+    "pipelineresources": "PipelineResource",
+    "pipelineruns": "PipelineRun",
+    "pipelines": "Pipeline",
+    "promotionruns": "PromotionRun",
+    "proxyplugins": "ProxyPlugin",
+    "releaseplanadmissions": "ReleasePlanAdmission",
+    "releaseplans": "ReleasePlan",
+    "releases": "Release",
+    "releasestrategies": "ReleaseStrategy",
+    "remotesecrets": "RemoteSecret",
+    "runs": "Run",
+    "snapshotenvironmentbindings": "SnapshotEnvironmentBinding",
+    "snapshots": "Snapshot",
+    "socialevents": "SocialEvent",
+    "spacebindings": "SpaceBinding",
+    "spacerequests": "SpaceRequest",
+    "spaces": "Space",
+    "spiaccesschecks": "SPIAccessCheck",
+    "spiaccesstokenbindings": "SPIAccessTokenBinding",
+    "spiaccesstokendataupdates": "SPIAccessTokenDataUpdate",
+    "spiaccesstokens": "SPIAccessToken",
+    "spifilecontentrequests": "SPIFileContentRequest",
+    "taskruns": "TaskRun",
+    "tasks": "Task",
+    "tiertemplates": "TierTemplate",
+    "toolchainclusters": "ToolChainCluster",
+    "toolchainconfigs": "ToolChainConfig",
+    "toolchainstatuses": "ToolChainStatus",
+    "useraccounts": "UserAccount",
+    "usersignups": "UserSignup",
+    "usertiers": "UserTier",
+    "verificationpolicies": "VerificationPolicy"
+  }'
+}
+
+jq \
+  --slurpfile uidm <(get-uid-map.sh) \
+  --slurpfile evvm <(event_verb_map) \
+  --slurpfile evsm <(event_subject_map) \
+  '.result | select($uidm[0][.userId])
+  | {
+      messageId, 
+      timestamp, 
+      type, 
+      userId: $uidm[0][.userId], 
+      event: "\($evsm[0][.event_subject] // .event_subject) \($evvm[0][.event_verb])", 
+      properties: (.properties|fromjson)
+    }
+  '


### PR DESCRIPTION
A set of shell scripts for:
- Fetching RHTAP UserJounrney events from Splunk
- Cross-referencing usernmaes in events with UserSignup resources to map from cluster username for SSO user IDs
- Formatting the events into Segment event records suitable for uploading via the bulk send API.