### PR TITLE
Limit Splunk query to last 4 hours

### DIFF
--- a/scripts/fetch-uj-records.sh
+++ b/scripts/fetch-uj-records.sh
@@ -9,40 +9,55 @@
 #   connecting to Splunk in a .netrc file
 #
 set -o pipefail -o errexit -o nounset
+#
+# ======= Parameters ======
+# The following variables can be set from outside the script by setting
+# similarly named environment variables.
+# 
+# The API URL to use for connecting to Splunk
+SPLUNK_API_URL="${SPLUNK_API_URL:-https://splunk-api.corp.redhat.com:8089}"
+# The Splunk app name that may store custom data objects we may use for the
+# query
+SPLUNK_APP_NAME="${SPLUNK_APP_NAME:-rh_rhtap}"
+# The Splunk index to fetch data from
+SPLUNK_INDEX="${SPLUNK_INDEX:-federated:rh_rhtap_stage_audit}" 
+# Specify the earliest time to retrieve records from
+# Value is a Splunk time string, defaults to 4 hours ago
+QUERY_EARLIEST_TIME="${QUERY_EARLIEST_TIME:-"-4hours"}"
+# Specify the latest time to retrieve records from
+# Value is a Splunk time string, defaults to now
+QUERY_LATEST_TIME="${QUERY_LATEST_TIME:-"-0hours"}"
+#
+# === End of parameters ===
 
-SPLUNK_API_URL=https://splunk-api.corp.redhat.com:8089
-SPLUNK_APP_NAME=rh_rhtap
 SPLUNK_APP_API_URL="$SPLUNK_API_URL/servicesNS/nobody/$SPLUNK_APP_NAME"
 SPLUNK_APP_SEARCH_URL="$SPLUNK_APP_API_URL/search/v2/jobs/export"
 
 FIELDS=(
-  auditID impersonatedUser.username objectRef.resource objectRef.namespace
-  objectRef.apiGroup objectRef.apiVersion objectRef.name verb
-  requestReceivedTimestamp
+  auditID impersonatedUser.username user.username objectRef.resource
+  objectRef.namespace objectRef.apiGroup objectRef.apiVersion objectRef.name
+  verb requestReceivedTimestamp
 )
-INDEX="federated:rh_rhtap_stage_audit" 
-SSO_LOOKUP="rhtap_staging_lookup"
 
 SQ_EV_SELECTOR='search 
-  index="'"$INDEX"'"
+  index="'"$SPLUNK_INDEX"'"
   log_type=audit 
   NOT verb IN (get, watch, list, deletecollection) 
   "objectRef.apiGroup" IN ("toolchain.dev.openshift.com", "appstudio.redhat.com", "tekton.dev")
-  "impersonatedUser.username"="*"
+  ("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*"))
   '
 SQ_DEDUP_FIELDS="eval dummy=0$(for F in "${FIELDS[@]}"; do echo -n ",$F=mvindex('$F', 0)"; done)"
 SQ_GEN_JSON="eval
   messageId=auditID,
   timestamp=requestReceivedTimestamp,
   type=\"track\",
-  userId='impersonatedUser.username',
+  userId=if(isnull('impersonatedUser.username'), 'user.username', 'impersonatedUser.username'),
   event_verb=verb,
   event_subject='objectRef.resource',
   properties=json_object(
     \"apiGroup\", 'objectRef.apiGroup',
     \"apiVersion\", 'objectRef.apiVersion',
     \"kind\", 'objectRef.resource',
-    \"namespace\", 'objectRef.namespace',
     \"name\", 'objectRef.name'
   )
   | fields messageId, timestamp, type, userId, event_verb, event_subject, properties | fields - _*
@@ -51,7 +66,9 @@ SQ_GEN_JSON="eval
 QUERY="$SQ_EV_SELECTOR | $SQ_DEDUP_FIELDS | $SQ_GEN_JSON"
 
 set -o xtrace
-curl -k -n \
-    "$SPLUNK_APP_SEARCH_URL" \
-    -d output_mode=json \
-    -d search="$QUERY"
+curl --netrc \
+  "$SPLUNK_APP_SEARCH_URL" \
+  --data output_mode=json \
+  --data earliest_time="$QUERY_EARLIEST_TIME" \
+  --data latest_time="$QUERY_LATEST_TIME" \
+  --data search="$QUERY"


### PR DESCRIPTION
Change `fetch-uj-records.sh` so that if only retrives records from the last 4 hours by default.

Also made some other consmetic changes:
- Moved all the script variables that may need to be customized for testing purposes or manually resolving issues to one documented spot.
- Made the query return operations made directly by users, not just ones that were done their behalf by system accounts.
- Removed the namespace field from the query results as that may expose PII to Segment.