### PR TITLE
Complete the process of sending data to Segment

### DIFF
--- a/scripts/mk-segment-batch-payload.sh
+++ b/scripts/mk-segment-batch-payload.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# mk-segment-batch-payload.sh
+#   Accept Segment event records on STDIN (One per-line) and wrap them together
+#   in a sigle JSON document suitable as payload for the Segment batch API.
+#
+set -o pipefail -o errexit -o nounset
+
+jq \
+  --compact-output \
+  --slurp \
+  '{batch: .}'

--- a/scripts/segment-mass-uploader.sh
+++ b/scripts/segment-mass-uploader.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# segment-mass-uploader.sh
+#   Accept a stream of Segment event JSON records from STDIN and pipes them to
+#   segment-uploader.sh in chunks suitable for the Segment API (No more than
+#   500KB).
+#
+set -o pipefail -o errexit -o nounset
+
+# Add script file directory to PATH so we can use other scripts in the same
+# directory
+SELFDIR="$(dirname "$0")"
+PATH="$SELFDIR:${PATH#$SELFDIR:}"
+
+# ======= Parameters ======
+# The following variables can be set from outside the script by setting
+# similarly named environment variables.
+#
+# The size of data chunk to send in bytes.
+# While the Segment API can accept calls up to 500KB, we send 490KB to leave
+# some room for JSON overhead and HTTP headers.
+SEGMENT_BATCH_DATA_SIZE="${SEGMENT_BATCH_DATA_SIZE:-$((490 * 1024))}"
+#
+# === End of parameters ===
+
+split \
+  --line-bytes "$SEGMENT_BATCH_DATA_SIZE" \
+  --filter="segment-uploader.sh"

--- a/scripts/segment-uploader.sh
+++ b/scripts/segment-uploader.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# segment-uploader.sh
+#   Get Segemnt event records from STDIN (One per-line) and POST them to the
+#   Segment batch API. The API is limited to max request size of 500KB, so no
+#   more then that should be sent as input.
+#   This script assumes we have a .netrc file with suitable credentials for
+#   Segment
+#
+set -o pipefail -o errexit -o nounset
+
+# Add script file directory to PATH so we can use other scripts in the same
+# directory
+SELFDIR="$(dirname "$0")"
+PATH="$SELFDIR:${PATH#$SELFDIR:}"
+
+# ======= Parameters ======
+# The following variables can be set from outside the script by setting
+# similarly named environment variables.
+#
+# The Segment API URL to use:
+SEGMENT_BATCH_API="${SEGMENT_BATCH_API:-https://api.segment.io/v1/batch}"
+# How many times to rety calling into Segment
+SEGMENT_RETRIES="${SEGMENT_RETRIES:-3}"
+#
+# === End of parameters ===
+
+set -o xtrace
+mk-segment-batch-payload.sh | \
+  curl --netrc \
+    "$SEGMENT_BATCH_API" \
+    --header "Content-Type: application/json" \
+    --fail \
+    --retry "$SEGMENT_RETRIES" \
+    --data @- \

--- a/scripts/splunk-to-segment.sh
+++ b/scripts/splunk-to-segment.sh
@@ -86,6 +86,7 @@ function event_subject_map() {
 }
 
 jq \
+  --compact-output \
   --slurpfile uidm <(get-uid-map.sh) \
   --slurpfile evvm <(event_verb_map) \
   --slurpfile evsm <(event_subject_map) \


### PR DESCRIPTION
Created tooling to send data into Segment.

For testing purposes the funcitonality was split into three scripts:
- `mk-segment-batch-payload.sh` - For creating JSON records for the Segment batch API
- `segment-uploader.sh` - For actually talking to the batch API
- `segment-mass-uploader.sh` - For splitting a stream of records into right-sized chunks for uploading and then repeatedly calling `segment-uploader.sh`

Also needed a slight change to `splunk-to-segment.sh` to make it emit compact records instead of formatted data.