### PR TITLE
fix(RHTAPWATCH-355): Remove false creation events

### DIFF
--- a/scripts/fetch-uj-records.sh
+++ b/scripts/fetch-uj-records.sh
@@ -45,6 +45,7 @@ SQ_EV_SELECTOR='search
   NOT verb IN (get, watch, list, deletecollection) 
   "objectRef.apiGroup" IN ("toolchain.dev.openshift.com", "appstudio.redhat.com", "tekton.dev")
   ("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*"))
+  (verb!=create OR "responseObject.metadata.resourceVersion"="*")
   '
 SQ_DEDUP_FIELDS="eval dummy=0$(for F in "${FIELDS[@]}"; do echo -n ",$F=mvindex('$F', 0)"; done)"
 SQ_GEN_JSON="eval


### PR DESCRIPTION
We found out that sometimes we get two resource create events in the audit log, both of which are accepted by the API server but only one of which is actually creating the resource record.

To tell which is the actual creation record we need to ensure we have a `resourceVersion` field in the `respobseObject` we get back from the creation action.