### PR TITLE
refactor(RHTAPWATCH-116): `querygen` Go program

### DIFF
--- a/cmd/querygen/main.go
+++ b/cmd/querygen/main.go
@@ -1,11 +1,32 @@
+/*
+QueryGen generates Splunk queries for obtaining RHTAP user journey events from
+the RHTAP cluster audit logs stored in Splunk.
+
+Usage:
+
+    querygen [flags]
+
+The flags are:
+
+    --index INDEX
+	    Specify the Splunk index to query.
+*/
 package main
 
 import (
+	"flag"
 	"fmt"
 
 	"github.com/redhat-appstudio/segment-bridge.git/querygen"
 )
 
+var index = flag.String(
+	"index",
+	"federated:rh_rhtap_stage_audit",
+	"the Splunk index to query",
+)
+
 func main() {
-	fmt.Println(querygen.GenQuery())
+	flag.Parse()
+	fmt.Println(querygen.GenApplicationQuery(*index))
 }

--- a/querygen/querygen.go
+++ b/querygen/querygen.go
@@ -1,5 +1,123 @@
+// Package querygen is used to generate Splunk queries for fetching user journey
+// events from the RHTAP K8s event log.
 package querygen
 
-func GenQuery() string {
-	return "Hi!"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	// UserIdExpr is a Splunk eval expression for obtaining the human username
+	// behind a given event even if the event action was done on their behalf by
+	// a service account
+	UserIdExpr = `if(isnull('impersonatedUser.username'),` +
+		`'user.username','impersonatedUser.username')`
+
+	// IncludeFieldsCmd is a Splunk query "fields" command for specifying which
+	// fields to include in the final query results. Since the structure of a
+	// Segment record is quite fixed, most queries should return the same
+	// fields.
+	IncludeFieldsCmd = `fields ` +
+		`messageId, timestamp, type, userId, event_verb, event_subject, properties`
+
+	// ExcludeFieldsCmd is a Splunk query "fields" command for removing fields
+	// from query results that splunk includes by default and we don't need.
+	ExcludeFieldsCmd = `fields - _*`
+)
+
+// GenDedupEval generates a Splunk "eval" command for converting multivalue
+// fields into single-value fields. See RHTAPWATCH-293 for why we need this.
+func GenDedupEval(fields []string) string {
+	var builder strings.Builder
+	builder.WriteString("eval ")
+	for i, field := range fields {
+		if i > 0 {
+			builder.WriteString(",")
+		}
+		fmt.Fprintf(&builder, `%s=mvindex('%s', 0)`, field, field)
+	}
+	return builder.String()
+}
+
+// GenPropertiesJSONExpr generates a Splunk "eval" expression for generating a
+// JSON object containing the fields and values specified in properties_map. The
+// field names are sorted in the output to make it predictable.
+func GenPropertiesJSONExpr(properties_map map[string]string) string {
+	var prop_args []string = make([]string, 0, len(properties_map))
+	for json_field, splunk_field := range properties_map {
+		prop_args = append(
+			prop_args,
+			fmt.Sprintf(`"%s",'%s'`, json_field, splunk_field),
+		)
+	}
+	sort.Strings(prop_args)
+	return fmt.Sprintf("json_object(%s)", strings.Join(prop_args, ","))
+}
+
+// TrackFieldSpec specifies which optional fields of a Segment track object do
+// we want to include in the query output. Queried objects should have the
+// values needed to generate these fields for this to work.
+type TrackFieldSpec struct {
+	with_userid, with_ev_verb, with_ev_subject bool
+}
+
+// Generate Splunk query commands for the output fields needed to build a
+// Segment track object. spec is used to toggle some optional fields that
+// different objects may/may not include while properties_map specified which
+// fields to include in the properties sub-object.
+func GenTrackFields(spec TrackFieldSpec, properties_map map[string]string) string {
+	var builder strings.Builder
+	builder.WriteString("eval ")
+	builder.WriteString(`messageId=auditID,`)
+	builder.WriteString(`timestamp=requestReceivedTimestamp,`)
+	builder.WriteString(`type="track",`)
+	if spec.with_userid {
+		builder.WriteString(`userId=` + UserIdExpr + `,`)
+	}
+	if spec.with_ev_verb {
+		builder.WriteString(`event_verb=verb,`)
+	}
+	if spec.with_ev_subject {
+		builder.WriteString(`event_subject='objectRef.resource',`)
+	}
+	builder.WriteString(`properties=` + GenPropertiesJSONExpr(properties_map))
+	builder.WriteString(`|` + IncludeFieldsCmd)
+	builder.WriteString(`|` + ExcludeFieldsCmd)
+	return builder.String()
+}
+
+// GenApplicationQuery returns a Splunk query for generating Segment events
+// representing AppStudio Application object events.
+func GenApplicationQuery(index string) string {
+	fields := []string{
+		"auditID",
+		"impersonatedUser.username",
+		"user.username",
+		"objectRef.resource",
+		"objectRef.namespace",
+		"objectRef.apiGroup",
+		"objectRef.apiVersion",
+		"objectRef.name",
+		"verb",
+		"requestReceivedTimestamp",
+	}
+	json_properties := map[string]string{
+		"apiGroup":   "objectRef.apiGroup",
+		"apiVersion": "objectRef.apiVersion",
+		"kind":       "objectRef.resource",
+		"name":       "objectRef.name",
+	}
+	return `search ` +
+		`index="` + index + `" ` +
+		`log_type=audit ` +
+		`NOT verb IN (get, watch, list, deletecollection) ` +
+		`"responseStatus.code" IN (200, 201) ` +
+		`"objectRef.apiGroup"="appstudio.redhat.com" ` +
+		`"objectRef.resource"="applications" ` +
+		`("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*")) ` +
+		`(verb!=create OR "responseObject.metadata.resourceVersion"="*")` +
+		`|` + GenDedupEval(fields) +
+		`|` + GenTrackFields(TrackFieldSpec{true, true, true}, json_properties)
 }

--- a/querygen/querygen_test.go
+++ b/querygen/querygen_test.go
@@ -4,10 +4,148 @@ import (
 	"testing"
 )
 
-func TestGenQuery(t *testing.T) {
-	expected := "Hi!"
-	out := GenQuery()
+func TestGenDedupEval(t *testing.T) {
+	fields := []string{
+		"auditID",
+		"impersonatedUser.username",
+		"user.username",
+		"objectRef.resource",
+		"objectRef.namespace",
+		"objectRef.apiGroup",
+		"objectRef.apiVersion",
+		"objectRef.name",
+		"verb",
+		"requestReceivedTimestamp",
+	}
+	expected := `eval ` +
+		`auditID=mvindex('auditID', 0),` +
+		`impersonatedUser.username=mvindex('impersonatedUser.username', 0),` +
+		`user.username=mvindex('user.username', 0),` +
+		`objectRef.resource=mvindex('objectRef.resource', 0),` +
+		`objectRef.namespace=mvindex('objectRef.namespace', 0),` +
+		`objectRef.apiGroup=mvindex('objectRef.apiGroup', 0),` +
+		`objectRef.apiVersion=mvindex('objectRef.apiVersion', 0),` +
+		`objectRef.name=mvindex('objectRef.name', 0),` +
+		`verb=mvindex('verb', 0),` +
+		`requestReceivedTimestamp=mvindex('requestReceivedTimestamp', 0)`
+	out := GenDedupEval(fields)
 	if out != expected {
-		t.Errorf("GenQuery() == %q, expected %q", out, expected)
+		t.Errorf("GenDedupEval() returns:\n  %q, expected\n  %q", out, expected)
+	}
+}
+
+func TestGenApplicationQuery(t *testing.T) {
+	fields := []string{
+		"auditID",
+		"impersonatedUser.username",
+		"user.username",
+		"objectRef.resource",
+		"objectRef.namespace",
+		"objectRef.apiGroup",
+		"objectRef.apiVersion",
+		"objectRef.name",
+		"verb",
+		"requestReceivedTimestamp",
+	}
+	json_properties := map[string]string{
+		"apiGroup":   "objectRef.apiGroup",
+		"apiVersion": "objectRef.apiVersion",
+		"kind":       "objectRef.resource",
+		"name":       "objectRef.name",
+	}
+	expected := `search ` +
+		`index="some_index" ` +
+		`log_type=audit ` +
+		`NOT verb IN (get, watch, list, deletecollection) ` +
+		`"responseStatus.code" IN (200, 201) ` +
+		`"objectRef.apiGroup"="appstudio.redhat.com" ` +
+		`"objectRef.resource"="applications" ` +
+		`("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*")) ` +
+		`(verb!=create OR "responseObject.metadata.resourceVersion"="*")` +
+		`|` + GenDedupEval(fields) +
+		`|` + GenTrackFields(TrackFieldSpec{true, true, true}, json_properties)
+	out := GenApplicationQuery("some_index")
+	if out != expected {
+		t.Errorf("GenApplicationQuery() = %v, want %v", out, expected)
+	}
+}
+
+func TestGenPropertiesJSONExpr(t *testing.T) {
+	type args struct {
+		properties_map map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Application query properties",
+			args: args{properties_map: map[string]string{
+				"apiGroup":   "objectRef.apiGroup",
+				"apiVersion": "objectRef.apiVersion",
+				"kind":       "objectRef.resource",
+				"name":       "objectRef.name",
+			}},
+			want: `json_object(` +
+				`"apiGroup",'objectRef.apiGroup',` +
+				`"apiVersion",'objectRef.apiVersion',` +
+				`"kind",'objectRef.resource',` +
+				`"name",'objectRef.name'` +
+				`)`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenPropertiesJSONExpr(tt.args.properties_map); got != tt.want {
+				t.Errorf("GenPropertiesJSONExpr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenTrackFields(t *testing.T) {
+	json_properties := map[string]string{
+		"apiGroup":   "objectRef.apiGroup",
+		"apiVersion": "objectRef.apiVersion",
+		"kind":       "objectRef.resource",
+		"name":       "objectRef.name",
+	}
+	type args struct {
+		spec           TrackFieldSpec
+		properties_map map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "with userid, verb, subject & app props",
+			args: args{
+				spec: TrackFieldSpec{
+					with_userid:     true,
+					with_ev_verb:    true,
+					with_ev_subject: true,
+				},
+				properties_map: json_properties,
+			},
+			want: `eval ` +
+				`messageId=auditID,` +
+				`timestamp=requestReceivedTimestamp,` +
+				`type="track",` +
+				`userId=` + UserIdExpr + `,` +
+				`event_verb=verb,` +
+				`event_subject='objectRef.resource',` +
+				`properties=` + GenPropertiesJSONExpr(json_properties) +
+				`|` + IncludeFieldsCmd + `|` + ExcludeFieldsCmd,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenTrackFields(tt.args.spec, tt.args.properties_map); got != tt.want {
+				t.Errorf("GenTrackFields() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/scripts/fetch-uj-records.sh
+++ b/scripts/fetch-uj-records.sh
@@ -33,38 +33,18 @@ QUERY_LATEST_TIME="${QUERY_LATEST_TIME:-"-0hours"}"
 SPLUNK_APP_API_URL="$SPLUNK_API_URL/servicesNS/nobody/$SPLUNK_APP_NAME"
 SPLUNK_APP_SEARCH_URL="$SPLUNK_APP_API_URL/search/v2/jobs/export"
 
-FIELDS=(
-  auditID impersonatedUser.username user.username objectRef.resource
-  objectRef.namespace objectRef.apiGroup objectRef.apiVersion objectRef.name
-  verb requestReceivedTimestamp
-)
+GO_PACKAGE="github.com/redhat-appstudio/segment-bridge.git"
 
-SQ_EV_SELECTOR='search 
-  index="'"$SPLUNK_INDEX"'"
-  log_type=audit 
-  NOT verb IN (get, watch, list, deletecollection) 
-  "objectRef.apiGroup" IN ("toolchain.dev.openshift.com", "appstudio.redhat.com", "tekton.dev")
-  ("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*"))
-  (verb!=create OR "responseObject.metadata.resourceVersion"="*")
-  '
-SQ_DEDUP_FIELDS="eval dummy=0$(for F in "${FIELDS[@]}"; do echo -n ",$F=mvindex('$F', 0)"; done)"
-SQ_GEN_JSON="eval
-  messageId=auditID,
-  timestamp=requestReceivedTimestamp,
-  type=\"track\",
-  userId=if(isnull('impersonatedUser.username'), 'user.username', 'impersonatedUser.username'),
-  event_verb=verb,
-  event_subject='objectRef.resource',
-  properties=json_object(
-    \"apiGroup\", 'objectRef.apiGroup',
-    \"apiVersion\", 'objectRef.apiVersion',
-    \"kind\", 'objectRef.resource',
-    \"name\", 'objectRef.name'
-  )
-  | fields messageId, timestamp, type, userId, event_verb, event_subject, properties | fields - _*
-"
+if command -v querygen > /dev/null; then
+  QUERYGEN=querygen
+elif command -v go > /dev/null; then
+  QUERYGEN="go run $GO_PACKAGE/cmd/querygen"
+else
+    echo 'Couldn`t find the querygen binary or go in $PATH' 1>&2
+    exit 127
+fi
 
-QUERY="$SQ_EV_SELECTOR | $SQ_DEDUP_FIELDS | $SQ_GEN_JSON"
+QUERY="$($QUERYGEN --index="$SPLUNK_INDEX")"
 
 set -o xtrace
 curl --netrc \


### PR DESCRIPTION
Create the `querygen` Go program for generating query strings for Splunk
and use that in `fetch-uj-records.sh` instead of the bash code we had
for this before.

Doing this as a first step to switching to having multiple queryes and
more complex ones. Using Go for this allows for more complex query
generating logic then wnat we can easily do in `bash`.

This PR depends on #12 