### PR TITLE
feat(RHTAPWATCH-374): Run multiple Splunk queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/redhat-appstudio/segment-bridge.git
 
 go 1.19
+
+require (
+	github.com/lithammer/dedent v1.1.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
+github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/querygen/querygen.go
+++ b/querygen/querygen.go
@@ -18,7 +18,7 @@ const (
 	// IncludeFieldsCmd is a Splunk query "fields" command for specifying which
 	// fields to include in the final query results. Since the structure of a
 	// Segment record is quite fixed, most queries should return the same
-	// fields. Some queries may return a subset of these vields but not
+	// fields. Some queries may return a subset of these fields by not
 	// calculating values for all of them.
 	IncludeFieldsCmd = `fields ` +
 		`messageId, timestamp, type, userId, namespace, event_verb, event_subject, properties`
@@ -28,7 +28,7 @@ const (
 	ExcludeFieldsCmd = `fields - _*`
 )
 
-// GenDedupEval generates a Splunk "eval" command for converting multivalue
+// GenDedupEval generates a Splunk "eval" command for converting multi value
 // fields into single-value fields. See RHTAPWATCH-293 for why we need this.
 func GenDedupEval(fields []string) string {
 	var builder strings.Builder

--- a/querygen/querygen.go
+++ b/querygen/querygen.go
@@ -18,9 +18,10 @@ const (
 	// IncludeFieldsCmd is a Splunk query "fields" command for specifying which
 	// fields to include in the final query results. Since the structure of a
 	// Segment record is quite fixed, most queries should return the same
-	// fields.
+	// fields. Some queries may return a subset of these vields but not
+	// calculating values for all of them.
 	IncludeFieldsCmd = `fields ` +
-		`messageId, timestamp, type, userId, event_verb, event_subject, properties`
+		`messageId, timestamp, type, userId, namespace, event_verb, event_subject, properties`
 
 	// ExcludeFieldsCmd is a Splunk query "fields" command for removing fields
 	// from query results that splunk includes by default and we don't need.
@@ -60,7 +61,7 @@ func GenPropertiesJSONExpr(properties_map map[string]string) string {
 // we want to include in the query output. Queried objects should have the
 // values needed to generate these fields for this to work.
 type TrackFieldSpec struct {
-	with_userid, with_ev_verb, with_ev_subject bool
+	with_userid, with_ev_verb, with_ev_subject, with_namespace bool
 }
 
 // Generate Splunk query commands for the output fields needed to build a
@@ -75,6 +76,9 @@ func GenTrackFields(spec TrackFieldSpec, properties_map map[string]string) strin
 	builder.WriteString(`type="track",`)
 	if spec.with_userid {
 		builder.WriteString(`userId=` + UserIdExpr + `,`)
+	}
+	if spec.with_namespace {
+		builder.WriteString(`namespace='objectRef.namespace',`)
 	}
 	if spec.with_ev_verb {
 		builder.WriteString(`event_verb=verb,`)
@@ -109,6 +113,11 @@ func GenApplicationQuery(index string) string {
 		"kind":       "objectRef.resource",
 		"name":       "objectRef.name",
 	}
+	track_fields := TrackFieldSpec{
+		with_userid: true,
+		with_ev_verb: true,
+		with_ev_subject: true,
+	}
 	return `search ` +
 		`index="` + index + `" ` +
 		`log_type=audit ` +
@@ -119,5 +128,44 @@ func GenApplicationQuery(index string) string {
 		`("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*")) ` +
 		`(verb!=create OR "responseObject.metadata.resourceVersion"="*")` +
 		`|` + GenDedupEval(fields) +
-		`|` + GenTrackFields(TrackFieldSpec{true, true, true}, json_properties)
+		`|` + GenTrackFields(track_fields, json_properties)
+}
+
+// GenApplicationQuery returns a Splunk query for generating Segment events
+// representing creation of AppStudio build PipelineRuns.
+func GenPipelineRunQuery(index string) string {
+	fields := []string{
+		"auditID",
+		"objectRef.resource",
+		"objectRef.namespace",
+		"objectRef.apiGroup",
+		"objectRef.apiVersion",
+		"verb",
+		"requestReceivedTimestamp",
+		"responseObject.metadata.labels.appstudio.openshift.io/application",
+		"responseObject.metadata.labels.appstudio.openshift.io/component",
+	}
+	json_properties := map[string]string{
+		"apiGroup":    "objectRef.apiGroup",
+		"apiVersion":  "objectRef.apiVersion",
+		"kind":        "objectRef.resource",
+		"application": "responseObject.metadata.labels.appstudio.openshift.io/application",
+		"component": "responseObject.metadata.labels.appstudio.openshift.io/component",
+	}
+	track_fields := TrackFieldSpec{
+		with_namespace: true,
+		with_ev_verb: true,
+		with_ev_subject: true,
+	}
+	return `search ` +
+		`index="` + index + `" ` +
+		`log_type=audit ` +
+		`verb=create ` +
+		`"responseStatus.code" IN (200, 201) ` +
+		`"objectRef.apiGroup"="tekton.dev" ` +
+		`"objectRef.resource"="pipelineruns" ` +
+		`"responseObject.metadata.labels.pipelines.appstudio.openshift.io/type"=build` +
+		`"responseObject.metadata.resourceVersion"="*"` +
+		`|` + GenDedupEval(fields) +
+		`|` + GenTrackFields(track_fields, json_properties)
 }

--- a/querygen/querygen_test.go
+++ b/querygen/querygen_test.go
@@ -16,6 +16,8 @@ func TestGenDedupEval(t *testing.T) {
 		"objectRef.name",
 		"verb",
 		"requestReceivedTimestamp",
+		"responseObject.metadata.labels.appstudio.openshift.io/application",
+		"responseObject.metadata.labels.appstudio.openshift.io/component",
 	}
 	expected := `eval ` +
 		`auditID=mvindex('auditID', 0),` +
@@ -27,7 +29,11 @@ func TestGenDedupEval(t *testing.T) {
 		`objectRef.apiVersion=mvindex('objectRef.apiVersion', 0),` +
 		`objectRef.name=mvindex('objectRef.name', 0),` +
 		`verb=mvindex('verb', 0),` +
-		`requestReceivedTimestamp=mvindex('requestReceivedTimestamp', 0)`
+		`requestReceivedTimestamp=mvindex('requestReceivedTimestamp', 0),` +
+		"responseObject.metadata.labels.appstudio.openshift.io/application" +
+		"=mvindex('responseObject.metadata.labels.appstudio.openshift.io/application', 0)," +
+		"responseObject.metadata.labels.appstudio.openshift.io/component" +
+		"=mvindex('responseObject.metadata.labels.appstudio.openshift.io/component', 0)" 
 	out := GenDedupEval(fields)
 	if out != expected {
 		t.Errorf("GenDedupEval() returns:\n  %q, expected\n  %q", out, expected)
@@ -53,6 +59,11 @@ func TestGenApplicationQuery(t *testing.T) {
 		"kind":       "objectRef.resource",
 		"name":       "objectRef.name",
 	}
+	track_fields := TrackFieldSpec{
+		with_userid: true,
+		with_ev_verb: true,
+		with_ev_subject: true,
+	}
 	expected := `search ` +
 		`index="some_index" ` +
 		`log_type=audit ` +
@@ -63,7 +74,7 @@ func TestGenApplicationQuery(t *testing.T) {
 		`("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*")) ` +
 		`(verb!=create OR "responseObject.metadata.resourceVersion"="*")` +
 		`|` + GenDedupEval(fields) +
-		`|` + GenTrackFields(TrackFieldSpec{true, true, true}, json_properties)
+		`|` + GenTrackFields(track_fields, json_properties)
 	out := GenApplicationQuery("some_index")
 	if out != expected {
 		t.Errorf("GenApplicationQuery() = %v, want %v", out, expected)
@@ -140,6 +151,26 @@ func TestGenTrackFields(t *testing.T) {
 				`properties=` + GenPropertiesJSONExpr(json_properties) +
 				`|` + IncludeFieldsCmd + `|` + ExcludeFieldsCmd,
 		},
+		{
+			name: "with namespace, verb, subject & app props",
+			args: args{
+				spec: TrackFieldSpec{
+					with_namespace:  true,
+					with_ev_verb:    true,
+					with_ev_subject: true,
+				},
+				properties_map: json_properties,
+			},
+			want: `eval ` +
+				`messageId=auditID,` +
+				`timestamp=requestReceivedTimestamp,` +
+				`type="track",` +
+				`namespace='objectRef.namespace',` +
+				`event_verb=verb,` +
+				`event_subject='objectRef.resource',` +
+				`properties=` + GenPropertiesJSONExpr(json_properties) +
+				`|` + IncludeFieldsCmd + `|` + ExcludeFieldsCmd,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -147,5 +178,45 @@ func TestGenTrackFields(t *testing.T) {
 				t.Errorf("GenTrackFields() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGenPipelineRunQuery(t *testing.T) {
+	fields := []string{
+		"auditID",
+		"objectRef.resource",
+		"objectRef.namespace",
+		"objectRef.apiGroup",
+		"objectRef.apiVersion",
+		"verb",
+		"requestReceivedTimestamp",
+		"responseObject.metadata.labels.appstudio.openshift.io/application",
+		"responseObject.metadata.labels.appstudio.openshift.io/component",
+	}
+	json_properties := map[string]string{
+		"apiGroup":    "objectRef.apiGroup",
+		"apiVersion":  "objectRef.apiVersion",
+		"kind":        "objectRef.resource",
+		"application": "responseObject.metadata.labels.appstudio.openshift.io/application",
+		"component": "responseObject.metadata.labels.appstudio.openshift.io/component",
+	}
+	track_fields := TrackFieldSpec{
+		with_namespace: true,
+		with_ev_verb: true,
+		with_ev_subject: true,
+	}
+	expected := `search ` +
+		`index="some_index" ` +
+		`log_type=audit ` +
+		`verb=create ` +
+		`"responseStatus.code" IN (200, 201) ` +
+		`"objectRef.apiGroup"="tekton.dev" ` +
+		`"objectRef.resource"="pipelineruns" ` +
+		`"responseObject.metadata.labels.pipelines.appstudio.openshift.io/type"=build` +
+		`"responseObject.metadata.resourceVersion"="*"` +
+		`|` + GenDedupEval(fields) +
+		`|` + GenTrackFields(track_fields, json_properties)
+	if out := GenPipelineRunQuery("some_index"); out != expected {
+		t.Errorf("GenPipelineRunQuery() = %v, want %v", out, expected)
 	}
 }

--- a/queryprint/queryprint.go
+++ b/queryprint/queryprint.go
@@ -1,0 +1,62 @@
+// Package queryprint contains utilities for printing one or more Splunk queries
+package queryprint
+
+import "strings"
+
+// QueryDesc includes a printable description of a Splunk query: A descriptive
+// title for it and the query string itself.
+type QueryDesc struct {
+	Title string
+	Query string
+}
+
+// PrettyPrintQueries prints the given set of queries in a human-readable format
+func PrettyPrintQueries(queries []QueryDesc) string {
+	var builder strings.Builder
+	for i, query := range queries {
+		if i > 0 {
+			builder.WriteString("\n")
+			builder.WriteString("\n")
+		}
+		builder.WriteString(query.Title)
+		builder.WriteString("\n")
+		builder.WriteString(strings.Repeat("-", len(query.Title)))
+		builder.WriteString("\n")
+		builder.WriteString(prettyPrintQuery(query.Query, "    "))
+	}
+	return builder.String()
+}
+
+func prettyPrintQuery(query string, indent string) string {
+	var builder strings.Builder
+	if len(query) < 60 {
+		builder.WriteString(indent)
+		builder.WriteString(query)
+	} else {
+		for i, line := range(strings.Split(query, "|")) {
+			if i > 0 {
+				builder.WriteString("\n")
+			}
+			builder.WriteString(indent)
+			if i > 0 {
+				builder.WriteString("|")
+			}
+			builder.WriteString(line)
+		}
+	}
+	return builder.String()
+}
+
+// MachinePrintQueries prints the given set of queries in a compact,
+// machine-readable format where queries are separated by NULL ("\x00")
+// characters
+func MachinePrintQueries(queries []QueryDesc) string {
+	var builder strings.Builder
+	for i, query := range queries {
+		if i > 0 {
+			builder.WriteRune('\x00')
+		}
+		builder.WriteString(query.Query)
+	}
+	return builder.String()
+}

--- a/queryprint/queryprint_test.go
+++ b/queryprint/queryprint_test.go
@@ -1,0 +1,122 @@
+// Package queryprint contains utilities for printing one or more Splunk queries
+package queryprint
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/lithammer/dedent"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+var dmp = diffmatchpatch.New()
+
+func TestPrettyPrintQueries(t *testing.T) {
+	tests := []struct {
+		name    string
+		queries []QueryDesc
+		want    string
+	}{
+		{
+			name:    "With no queries",
+			queries: []QueryDesc{},
+			want:    "",
+		},
+		{
+			name: "With a few short queries",
+			queries: []QueryDesc{
+				{"foo", "search index=foo"},
+				{"foo count", "search index=foo | stats count by bar"},
+				{"foo baz", "search index=foo bar=baz | fields bar, bal"},
+			},
+			want: strings.TrimSpace(Dedent(`
+				foo
+				---
+				    search index=foo
+
+				foo count
+				---------
+				    search index=foo | stats count by bar
+
+				foo baz
+				-------
+				    search index=foo bar=baz | fields bar, bal`,
+			)),
+		},
+		{
+			name: "With a long query",
+			queries: []QueryDesc{{
+				"Some long query",
+				`search index=some_long_index_name log_type=awesome match=value` +
+					`|eval custom_field=some_expression,` +
+					`other_field=other_expression` +
+					`|fields fields,shown,in,results`,
+			}},
+			want: strings.TrimSpace(Dedent(`
+				Some long query
+				---------------
+				    search index=some_long_index_name log_type=awesome match=value
+				    |eval custom_field=some_expression,other_field=other_expression
+				    |fields fields,shown,in,results
+			`)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PrettyPrintQueries(tt.queries); got != tt.want {
+				diff := dmp.DiffPrettyText(dmp.DiffMain(tt.want, got, true))
+				t.Errorf(
+					"PrettyPrintQueries() incorrect output. "+
+						"Diff:\n%v\nGot:\n%v\nWant:\n%v",
+					diff, got, tt.want,
+				)
+			}
+		})
+	}
+}
+
+func TestMachinePrintQueries(t *testing.T) {
+	tests := []struct {
+		name string
+		queries []QueryDesc
+		want string
+	}{
+		{
+			name:    "With no queries",
+			queries: []QueryDesc{},
+			want:    "",
+		},
+		{
+			name: "With a few short queries",
+			queries: []QueryDesc{
+				{"foo", "search index=foo"},
+				{"foo count", "search index=foo | stats count by bar"},
+				{"foo baz", "search index=foo bar=baz | fields bar, bal"},
+			},
+			want: "search index=foo\x00" +
+				"search index=foo | stats count by bar\x00" +
+				"search index=foo bar=baz | fields bar, bal",
+		},
+		{
+			name: "With a long query",
+			queries: []QueryDesc{{
+				"Some long query",
+				`search index=some_long_index_name log_type=awesome match=value` +
+					`|eval custom_field=some_expression,` +
+					`other_field=other_expression` +
+					`|fields fields,shown,in,results`,
+			}},
+			want: `search index=some_long_index_name log_type=awesome match=value` +
+			`|eval custom_field=some_expression,` +
+			`other_field=other_expression` +
+			`|fields fields,shown,in,results`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MachinePrintQueries(tt.queries); got != tt.want {
+				t.Errorf("MachinePrintQueries() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add support in `querygen` for generating and printing multiple queries as well as support in `fetch-uj-records.sh` run running them.

In the process also add one additional query for querying PipelineRuns