### PR TITLE
test(RHTAPWATCH-311): Mini HTTP test framework

### DIFF
--- a/webfixture/webfixture.go
+++ b/webfixture/webfixture.go
@@ -1,0 +1,38 @@
+// Package webfixture includes a simple HTTP-server test fixture that collects
+// the requests made to it
+package webfixture
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+)
+
+// RequestTrace represents simple data about a web request
+type RequestTrace struct {
+	Method,	Path, Body string
+}
+
+// TraceRequestsFrom runs a small web server, and then invokes a provided test
+// function while passing it the server URL and an HTTP client. The requests
+// made to the web server while the test function is running are then logged
+// and returned.
+func TraceRequestsFrom(test_func func(url string, c *http.Client)) (requests []RequestTrace) {
+	requests_chan := make(chan RequestTrace)
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		requests_chan <- RequestTrace{r.Method, r.URL.Path, string(body)}
+	}))
+	defer svr.Close()
+	defer close(requests_chan)
+	go func() {
+		for request := range requests_chan {
+			requests = append(requests, request)
+		}
+	}()
+	test_func(svr.URL, svr.Client())
+	return
+}

--- a/webfixture/webfixture_test.go
+++ b/webfixture/webfixture_test.go
@@ -1,0 +1,62 @@
+// Package webfixture includes a simple HTTP-server test fixture that collects
+// the requests made to it
+package webfixture
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTraceRequestsFrom(t *testing.T) {
+	tests := []struct {
+		name         string
+		test_func func(url string, c *http.Client)
+		want []RequestTrace
+	}{
+		{
+			name: "Single GET",
+			test_func: func(url string, c *http.Client) {
+				c.Get(url)
+			},
+			want: []RequestTrace{
+				{"GET", "/", ""},
+			},
+		},
+		{
+			name: "Multiple GETs",
+			test_func: func(url string, c *http.Client) {
+				c.Get(url + "/foo")
+				c.Get(url + "/bar")
+			},
+			want: []RequestTrace{
+				{"GET", "/foo", ""},
+				{"GET", "/bar", ""},
+			},
+		},
+		{
+			name: "POST request with a body",
+			test_func: func(url string, c *http.Client) {
+				c.Post(url, "text/json", strings.NewReader(
+					`{"foo": "bar}`,
+				))
+			},
+			want: []RequestTrace{
+				{"POST", "/", `{"foo": "bar}`},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRequests := TraceRequestsFrom(tt.test_func)
+			if !reflect.DeepEqual(gotRequests, tt.want) {
+				t.Errorf(
+					"TraceRequestsFrom() = %v, want %v",
+					gotRequests,
+					tt.want,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding a little test function that would be useful for testing things that make simple calls into web servers, and do not care too much about the response. The main candidate for sing this is
 `segment-mass-uploader.sh`.