### PR TITLE
chore(RHTAPWATCH-373): Support query-originated event verbs

### DIFF
--- a/scripts/splunk-to-segment.sh
+++ b/scripts/splunk-to-segment.sh
@@ -96,7 +96,7 @@ jq \
       timestamp, 
       type, 
       userId: $uidm[0][.userId], 
-      event: "\($evsm[0][.event_subject] // .event_subject) \($evvm[0][.event_verb])", 
+      event: "\($evsm[0][.event_subject] // .event_subject) \($evvm[0][.event_verb] // .event_verb)", 
       properties: (.properties|fromjson)
     }
   '


### PR DESCRIPTION
When event_verb returned from Splunk query not present in the event_verb_map, pass original value instead of null