### PR TITLE
RHTAPWATCH-154: Produce a segment event when a build PipelineRun starts

### DIFF
--- a/cmd/querygen/main.go
+++ b/cmd/querygen/main.go
@@ -47,8 +47,12 @@ func main() {
 			Query: querygen.GenApplicationQuery(*index),
 		},
 		{
-			Title: "PipelineRun creations for build pipeline",
-			Query: querygen.GenPipelineRunQuery(*index),
+			Title: "Build PipelineRun creation events",
+			Query: querygen.GenBuildPipelineRunCreatedQuery(*index),
+		},
+		{
+			Title: "Build PipelineRun started events",
+			Query: querygen.GenBuildPipelineRunStartedQuery(*index),
 		},
 	}))
 }

--- a/querygen/querygen.go
+++ b/querygen/querygen.go
@@ -7,12 +7,12 @@ package querygen
 func GenApplicationQuery(index string) string {
 	q, _ := UserJourneyQueryGen(
 		index,
-		`verb=create ` +
-		`"responseStatus.code" IN (200, 201) ` +
-		`"objectRef.apiGroup"="appstudio.redhat.com" ` +
-		`"objectRef.resource"="applications" ` +
-		`("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*")) ` +
-		`(verb!=create OR "responseObject.metadata.resourceVersion"="*")`,
+		`verb=create `+
+			`"responseStatus.code" IN (200, 201) `+
+			`"objectRef.apiGroup"="appstudio.redhat.com" `+
+			`"objectRef.resource"="applications" `+
+			`("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*")) `+
+			`(verb!=create OR "responseObject.metadata.resourceVersion"="*")`,
 		[]string{"name", "userId"},
 	)
 	return q
@@ -23,13 +23,13 @@ func GenApplicationQuery(index string) string {
 func GenPipelineRunQuery(index string) string {
 	q, _ := UserJourneyQueryGen(
 		index,
-		`verb=create ` +
-		`"responseStatus.code" IN (200, 201) ` +
-		`"objectRef.apiGroup"="tekton.dev" ` +
-		`"objectRef.resource"="pipelineruns" ` +
-		`"responseObject.metadata.labels.pipelines.appstudio.openshift.io/type"=build` +
-		`"responseObject.metadata.resourceVersion"="*"`,
-		[]string{"namespace","application","component"},
+		`verb=create `+
+			`"responseStatus.code" IN (200, 201) `+
+			`"objectRef.apiGroup"="tekton.dev" `+
+			`"objectRef.resource"="pipelineruns" `+
+			`"responseObject.metadata.labels.pipelines.appstudio.openshift.io/type"=build`+
+			`"responseObject.metadata.resourceVersion"="*"`,
+		[]string{"namespace", "application", "component"},
 	)
 	return q
 }

--- a/querygen/querygen.go
+++ b/querygen/querygen.go
@@ -18,17 +18,41 @@ func GenApplicationQuery(index string) string {
 	return q
 }
 
-// GenPipelineRunQuery returns a Splunk query for generating Segment events
+// GenBuildPipelineRunCreatedQuery returns a Splunk query for generating Segment events
 // representing creation of AppStudio build PipelineRuns.
-func GenPipelineRunQuery(index string) string {
+func GenBuildPipelineRunCreatedQuery(index string) string {
 	q, _ := UserJourneyQueryGen(
 		index,
 		`verb=create `+
 			`"responseStatus.code" IN (200, 201) `+
 			`"objectRef.apiGroup"="tekton.dev" `+
 			`"objectRef.resource"="pipelineruns" `+
-			`"responseObject.metadata.labels.pipelines.appstudio.openshift.io/type"=build`+
-			`"responseObject.metadata.resourceVersion"="*"`,
+			`"responseObject.metadata.labels.pipelines.appstudio.openshift.io/type"=build `+
+			`"responseObject.metadata.resourceVersion"="*" `+
+			`| eval event="Build PipelineRun created" `,
+		[]string{"namespace", "application", "component"},
+	)
+	return q
+}
+
+// GenBuildPipelineRunStartedQuery returns a Splunk query for generating Segment events
+// representing the start of AppStudio build PipelineRuns.
+func GenBuildPipelineRunStartedQuery(index string) string {
+	q, _ := UserJourneyQueryGen(
+		index,
+		`verb=update `+
+			`"responseStatus.code"=200 `+
+			`"objectRef.apiGroup"="tekton.dev" `+
+			`"objectRef.resource"="pipelineruns" `+
+			`"objectRef.subresource"="status" `+
+			`"responseObject.metadata.labels.pipelines.appstudio.openshift.io/type"=build `+
+			`"responseObject.metadata.resourceVersion"="*" `+
+			`"responseObject.status.startTime"="*" `+
+			`| eval event="Build PipelineRun started" `+
+			`| spath path=responseObject.status.conditions{} output=conditions `+
+			`| mvexpand conditions `+
+			`| spath input=conditions `+
+			`| where type="Succeeded" AND reason="Running" AND like(message, "Tasks Completed: 0 %") `,
 		[]string{"namespace", "application", "component"},
 	)
 	return q

--- a/querygen/querygen_test.go
+++ b/querygen/querygen_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGenApplicationQuery(t *testing.T) {
 	out := GenApplicationQuery("some_index")
-	assert.NotEqual(t, "" , out)
+	assert.NotEqual(t, "", out)
 }
 
 func TestGenPipelineRunQuery(t *testing.T) {

--- a/querygen/querygen_test.go
+++ b/querygen/querygen_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Testes in this file are simply making sure we're getting queries back
+// Tests in this file are simply making sure we're getting queries back
 // which means we're passing in valid field names. Our query generation code
 // already makes sure that the queries we generate are valid
 
@@ -15,7 +15,12 @@ func TestGenApplicationQuery(t *testing.T) {
 	assert.NotEqual(t, "", out)
 }
 
-func TestGenPipelineRunQuery(t *testing.T) {
-	out := GenPipelineRunQuery("some_index")
+func TestGenBuildPipelineRunCreatedQuery(t *testing.T) {
+	out := GenBuildPipelineRunCreatedQuery("some_index")
+	assert.NotEqual(t, "", out)
+}
+
+func TestGenBuildPipelineRunStartedQuery(t *testing.T) {
+	out := GenBuildPipelineRunStartedQuery("some_index")
 	assert.NotEqual(t, "", out)
 }

--- a/querygen/userjourney_fs.go
+++ b/querygen/userjourney_fs.go
@@ -11,6 +11,7 @@ var UserJourneyFieldSet = FieldSet{
 	"type":          {srcExpr: `"track"`},
 	"userId":        {srcFields: []string{"impersonatedUser.username", "user.username"}},
 	"namespace":     {srcFields: []string{"objectRef.namespace"}},
+	"event":         {srcFields: []string{"event"}},
 	"event_verb":    {srcFields: []string{"verb"}},
 	"event_subject": {srcFields: []string{"objectRef.resource"}},
 	"apiGroup":      {subObj: "properties", srcFields: []string{"objectRef.apiGroup"}},

--- a/querygen/userjourney_fs_test.go
+++ b/querygen/userjourney_fs_test.go
@@ -22,7 +22,7 @@ func TestUserJourneyQueryGen(t *testing.T) {
 		`"kind",'objectRef.resource'` +
 		`)` +
 		`|fields ` +
-		`event_subject,event_verb,messageId,namespace,` +
+		`event,event_subject,event_verb,messageId,namespace,` +
 		`properties,timestamp,type,userId` +
 		`|` + excludeFieldsCmd
 	type args struct {

--- a/querygen/userjourney_fs_test.go
+++ b/querygen/userjourney_fs_test.go
@@ -37,8 +37,8 @@ func TestUserJourneyQueryGen(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "With invalid fields",
-			args: args{fields: []string{"no_such"}},
+			name:    "With invalid fields",
+			args:    args{fields: []string{"no_such"}},
 			wantErr: true,
 		},
 		{
@@ -62,9 +62,9 @@ func TestUserJourneyQueryGen(t *testing.T) {
 		{
 			name: "With an extra field and predicate",
 			args: args{
-				index: "idx2",
+				index:     "idx2",
 				predicate: "verb=create",
-				fields: []string{"userId"},
+				fields:    []string{"userId"},
 			},
 			want: fmt.Sprintf(
 				queryTemplate,
@@ -80,8 +80,8 @@ func TestUserJourneyQueryGen(t *testing.T) {
 					"impersonatedUser.username",
 					"user.username",
 				}),
-				`userId=if(isnull('impersonatedUser.username'),` +
-				`'user.username','impersonatedUser.username'),`,
+				`userId=if(isnull('impersonatedUser.username'),`+
+					`'user.username','impersonatedUser.username'),`,
 			),
 		},
 	}

--- a/scripts/fetch-uj-records.sh
+++ b/scripts/fetch-uj-records.sh
@@ -56,4 +56,4 @@ $QUERYGEN -0 --index="$SPLUNK_INDEX" \
     --data output_mode=json \
     --data earliest_time="$QUERY_EARLIEST_TIME" \
     --data latest_time="$QUERY_LATEST_TIME" \
-    --data search=Q
+    --data-urlencode search=Q

--- a/scripts/splunk-to-segment.sh
+++ b/scripts/splunk-to-segment.sh
@@ -104,7 +104,7 @@ jq \
       timestamp, 
       type, 
       userId: .ssoId,
-      event: "\($evsm[0][.event_subject] // .event_subject) \($evvm[0][.event_verb] // .event_verb)", 
+      event: (.event // "\($evsm[0][.event_subject] // .event_subject) \($evvm[0][.event_verb] // .event_verb)"),
       properties: (.properties|fromjson)
     }
   '


### PR DESCRIPTION
A `PipelineRun` started event is detected by searching for update events on the `status` subresource where the `Succeeded` condition has a reason of `Running` with 0 tasks complete.