### PR TITLE
chore(RHTAPWATCH-95): Produce a segment event when the clair-scan task completes

### DIFF
--- a/cmd/querygen/main.go
+++ b/cmd/querygen/main.go
@@ -54,5 +54,9 @@ func main() {
 			Title: "Build PipelineRun started events",
 			Query: querygen.GenBuildPipelineRunStartedQuery(*index),
 		},
+		{
+			Title: "Clair scan TaskRun completion events",
+			Query: querygen.GenClairScanCompletedQuery(*index),
+		},
 	}))
 }

--- a/querygen/querygen.go
+++ b/querygen/querygen.go
@@ -57,3 +57,33 @@ func GenBuildPipelineRunStartedQuery(index string) string {
 	)
 	return q
 }
+
+// GenClairScanCompletedQuery returns a Splunk query for generating Segment events
+// when the clair-scan task completes.
+func GenClairScanCompletedQuery(index string) string {
+	q, _ := UserJourneyQueryGen(
+		index,
+		`verb=update `+
+			`"responseStatus.code"=200 `+
+			`"objectRef.apiGroup"="tekton.dev" `+
+			`"objectRef.resource"="taskruns" `+
+			`"objectRef.subresource"="status" `+
+			`"requestObject.metadata.labels.tekton.dev/pipelineTask"="clair-scan" `+
+			`"responseObject.status.completionTime"="*" `+
+			`| spath responseObject.status.conditions{} `+
+			`| mvexpand responseObject.status.conditions{} `+
+			`| search responseObject.status.conditions{}.type="Succeeded" `+
+			`responseObject.status.conditions{}.reason="Succeeded" `+
+			`responseObject.status.conditions{}.status="True" `+
+			`| spath responseObject.status.taskResults{} `+
+			`| mvexpand responseObject.status.taskResults{} `+
+			`| search responseObject.status.taskResults{}.name="CLAIR_SCAN_RESULT" `+
+			`| spath input=responseObject.status.taskResults{}.value path=vulnerabilities.critical output=clair_scan_result.vulnerabilities.critical `+
+			`| spath input=responseObject.status.taskResults{}.value path=vulnerabilities.high output=clair_scan_result.vulnerabilities.high `+
+			`| spath input=responseObject.status.taskResults{}.value path=vulnerabilities.medium output=clair_scan_result.vulnerabilities.medium `+
+			`| spath input=responseObject.status.taskResults{}.value path=vulnerabilities.low output=clair_scan_result.vulnerabilities.low `+
+			`| eval event="Clair scan TaskRun completed"`,
+		[]string{"namespace", "application", "component", "vulnerabilities_critical", "vulnerabilities_high", "vulnerabilities_medium", "vulnerabilities_low"},
+	)
+	return q
+}

--- a/querygen/querygen_test.go
+++ b/querygen/querygen_test.go
@@ -24,3 +24,8 @@ func TestGenBuildPipelineRunStartedQuery(t *testing.T) {
 	out := GenBuildPipelineRunStartedQuery("some_index")
 	assert.NotEqual(t, "", out)
 }
+
+func TestGenClairScanCompletedQuery(t *testing.T) {
+	out := GenClairScanCompletedQuery("some_index")
+	assert.NotEqual(t, "", out)
+}

--- a/querygen/userjourney_fs.go
+++ b/querygen/userjourney_fs.go
@@ -27,6 +27,22 @@ var UserJourneyFieldSet = FieldSet{
 		subObj:    "properties",
 		srcFields: []string{"responseObject.metadata.labels.appstudio.openshift.io/component"},
 	},
+	"vulnerabilities_critical": {
+		subObj:    "properties",
+		srcFields: []string{"clair_scan_result.vulnerabilities.critical"},
+	},
+	"vulnerabilities_high": {
+		subObj:    "properties",
+		srcFields: []string{"clair_scan_result.vulnerabilities.high"},
+	},
+	"vulnerabilities_medium": {
+		subObj:    "properties",
+		srcFields: []string{"clair_scan_result.vulnerabilities.medium"},
+	},
+	"vulnerabilities_low": {
+		subObj:    "properties",
+		srcFields: []string{"clair_scan_result.vulnerabilities.low"},
+	},
 }
 
 var UserJourneyCommonFields = [...]string{


### PR DESCRIPTION
Produce a segment event when the clair-scan task completes

Task:
[RHTAPWATCH-95](https://issues.redhat.com/browse/RHTAPWATCH-95)