### PR TITLE
chore(RHTAPWATCH-183): Produce a segment event when a Release succeeds or fails.

### DIFF
--- a/cmd/querygen/main.go
+++ b/cmd/querygen/main.go
@@ -62,5 +62,9 @@ func main() {
 			Title: "Build PipelineRun Completed or Failed event",
 			Query: querygen.GenBuildPipelineRunCompletedQuery(*index),
 		},
+		{
+			Title: "Release Succeeded or Failed events",
+			Query: querygen.GenReleaseCompletedQuery(*index),
+		},
 	}))
 }

--- a/querygen/querygen_test.go
+++ b/querygen/querygen_test.go
@@ -34,3 +34,8 @@ func TestGenBuildPipelineRunCompletedQuery(t *testing.T) {
 	out := GenBuildPipelineRunCompletedQuery("some_index")
 	assert.NotEqual(t, "", out)
 }
+
+func TestGenReleaseCompletedQuery(t *testing.T) {
+	out := GenReleaseCompletedQuery("some_index")
+	assert.NotEqual(t, "", out)
+}

--- a/querygen/userjourney_fs.go
+++ b/querygen/userjourney_fs.go
@@ -37,12 +37,12 @@ var UserJourneyFieldSet = FieldSet{
 		srcExpr:   `replace('responseObject.metadata.annotations.build.appstudio.openshift.io/repo',"^([^?]*)(.*)?","\1")`,
 	},
 	"status_message": {
-		subObj:    "properties",
-		srcFields: []string{"responseObject.status.conditions{}.message"},
+		subObj:  "properties",
+		srcExpr: `mvindex('responseObject.status.conditions{}.message', 0)`,
 	},
 	"status_reason": {
-		subObj:    "properties",
-		srcFields: []string{"responseObject.status.conditions{}.reason"},
+		subObj:  "properties",
+		srcExpr: `mvindex('responseObject.status.conditions{}.reason', 0)`,
 	},
 	"target_branch": {
 		subObj:    "properties",


### PR DESCRIPTION
# Description
Produce a segment event when a Release succeeds or fails.
- Ensure that Release resource events are Sent to Segment
- Ensure that the resource success/failure state changes are reflected to Segment.

## Issue ticket number and link
[RHTAPWATCH-183](https://issues.redhat.com/browse/RHTAPWATCH-183)

## How Has This Been Tested?
Tested the query locally in Splunk.
