### PR TITLE
chore(RHTAPWATCH-481): move Splunk's image buildtime database

### DIFF
--- a/splunk/Dockerfile
+++ b/splunk/Dockerfile
@@ -28,7 +28,7 @@ USER root
 
 RUN mkdir -p /opt/splunk/var/lib/splunk
 COPY --chmod=777 --from=builder /opt/splunk/etc/apps/search/local/indexes.conf /opt/splunk/etc/apps/search/local/indexes.conf
-COPY --chmod=777 --from=builder /opt/splunk/splunk/ /opt/splunk/var/lib/splunk/
+COPY --chmod=777 --from=builder /var/splunk_buildtime_db/splunk /opt/splunk/var/lib/splunk/
 
 ENV SPLUNKD_SSL_ENABLE=false
 

--- a/splunk/scripts/pre-run.sh
+++ b/splunk/scripts/pre-run.sh
@@ -22,7 +22,8 @@ done
 bash /opt/splunk/log_indexing.sh
 
 # Copy the whole Splunk DB to an accessible directory
-sudo cp -r /opt/splunk/var/lib/splunk/ /opt/splunk/splunk
+sudo mkdir -p /var/splunk_buildtime_db/splunk
+sudo cp -r /opt/splunk/var/lib/splunk/ /var/splunk_buildtime_db/splunk
 
 # Shut down the Splunk service
 sudo -u splunk /opt/splunk/bin/splunk stop


### PR DESCRIPTION
# Description

In the Splunk's dockerfile, the Splunk DB is being moved to `/opt/splunk/splunk` so it'll be to allow copying it during build time to the second stage of the build.

This change place the Splunk DB in a dedicated directory under /var/ so that it won't be confused for a Splunk binary directory

## Issue ticket number and link
[RHTAPWATCH-481](https://issues.redhat.com/browse/RHTAPWATCH-481)

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
Manual tests building and running the image with podman, 
entering the container to check that everything in place,
as well as running the unit tests that use the Splunk image.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added meaningful description with JIRA/GitHub issue key (if applicable)
