### PR TITLE
fix(RHTAPWATCH-507): failing to build kwok image

### DIFF
--- a/kwok/Dockerfile
+++ b/kwok/Dockerfile
@@ -3,8 +3,7 @@ FROM registry.k8s.io/kwok/cluster:v0.3.0-k8s.v1.27.3
 ARG CLUSTER_NAME=kwok
 ENV CLUSTER_NAME=${CLUSTER_NAME}
 
-COPY --chmod=755 kwok/user-signups.sh kwok/entrypoint.sh kwok/toolchain.dev.openshift.com_usersignups.yaml ./
-COPY --chown=root:root --chmod=755 scripts/* /usr/local/bin
+COPY --chmod=755 user-signups.sh entrypoint.sh toolchain.dev.openshift.com_usersignups.yaml ./
 
 RUN KWOK_KUBE_APISERVER_PORT=0 kwokctl create cluster --name "$CLUSTER_NAME" || exit 1 && \
     kwokctl --name="$CLUSTER_NAME" kubectl apply -f toolchain.dev.openshift.com_usersignups.yaml && \

--- a/kwok/kwok_container_template.yml
+++ b/kwok/kwok_container_template.yml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
   - name: kwok
-    image: quay.io/srivickynesh/kwok:kwok-bundle
+    image: kwok
     ports:
     - containerPort: 8080
       hostPort: 8080


### PR DESCRIPTION
Building the `kwok` image via `podman kube play` was failing because the image Dockerfile was assuming the build context directory is the repo root instead of the `kwok/` directory where the file resides.