### PR TITLE
chore: pre-filled Splunk container definition

### DIFF
--- a/splunk/splunk_container_default.yaml
+++ b/splunk/splunk_container_default.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: splunk-pod
+spec:
+  containers:
+    - args:
+        - start-service
+      env:
+        - name: SPLUNK_START_ARGS
+          value: '--accept-license'
+        - name: SPLUNK_PASSWORD
+          value: Password
+      image: splunk
+      ports:
+        - containerPort: 8000
+          hostPort: 8000
+        - containerPort: 8089
+          hostPort: 8089
+


### PR DESCRIPTION
# Description

Adds a pre-filled version of `splunk_container_template` with default details to allow easily running the pod manually with `podman kube build`

## Issue ticket number and link
https://github.com/redhat-appstudio/segment-bridge/pull/41#discussion_r1321900272

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

manually tested with `podman kube build`

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
