### PR TITLE
chore: corrected exposed port for Splunk

### DIFF
--- a/splunk/Dockerfile
+++ b/splunk/Dockerfile
@@ -21,7 +21,7 @@ FROM docker.io/splunk/splunk@sha256:0bcd9c9f836cfb72b80b5ff8deec692b561473e68b9e
 
 ENV SPLUNK_START_ARGS=--accept-license
 
-EXPOSE 8080
+EXPOSE 8000
 EXPOSE 8089
 
 USER root


### PR DESCRIPTION
# Description

Splunk communicate on port 8000 and 8089, yet the Dockerfile pointed at 8080 as an exposed port, instead of 8000.
