### PR TITLE
chore: pre-filled Kwok container definition

### DIFF
--- a/kwok/kwok_container_default.yml
+++ b/kwok/kwok_container_default.yml
@@ -1,0 +1,16 @@
+---
+#
+# Save the output of this file and use kubectl create -f to import
+# it into Kubernetes.
+# Created with podman-4.5.1
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kwok-pod
+spec:
+  containers:
+    - image: kwok
+      name: kwok
+      ports:
+        - containerPort: 8080
+          hostPort: 8080


### PR DESCRIPTION
# Description

Adds a pre-filled version of `kwok_container_template` with default details to allow easily running the pod manually with `podman kube build`

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
