### PR TITLE
fix(RHTAPWATCH-522): container builds flakiness

### DIFF
--- a/kwok/getuidmap_test.go
+++ b/kwok/getuidmap_test.go
@@ -5,35 +5,41 @@ import (
 	"testing"
 
 	"github.com/redhat-appstudio/segment-bridge.git/containerfixture"
+	"github.com/redhat-appstudio/segment-bridge.git/utils"
 	"github.com/stretchr/testify/assert"
 )
 
 //go:embed kwok_container_template.yml
 var kwokServiceManifest string
 
+func withKwokContainer(t *testing.T, testFunc func(containerfixture.FixtureInfo)) {
+	filepath, _ := utils.GetCallerFileDirPath(1)
+	containerfixture.WithServiceContainer(
+		t, "kwok", filepath, kwokServiceManifest, testFunc,
+	)
+}
+
 func TestGetUIDMap(t *testing.T) {
-	containerfixture.WithServiceContainer(t, kwokServiceManifest,
-		func(deployment containerfixture.FixtureInfo) {
+	withKwokContainer(t, func(deployment containerfixture.FixtureInfo) {
+		m, err := setUpClusterConfiguration()
+		assert.NoError(t, err, "Failed to set up cluster configuration")
 
-			m, err := setUpClusterConfiguration()
-			assert.NoError(t, err, "Failed to set up cluster configuration")
+		testCases := []struct {
+			name   string
+			input  map[string]int64
+			expect bool
+		}{
+			{"Usersignup validation", m, true}, // using 'm' returned from setUpClusterConfiguration
+			{"Correct validation", map[string]int64{"petta": 12345678, "blee1": 87654321}, true},
+			{"empty key", map[string]int64{"": 12345678}, false},
+			{"no value key", map[string]int64{"<no value>": 87654321}, false},
+			{"empty map", map[string]int64{}, false},
+		}
 
-			testCases := []struct {
-				name   string
-				input  map[string]int64
-				expect bool
-			}{
-				{"Usersignup validation", m, true}, // using 'm' returned from setUpClusterConfiguration
-				{"Correct validation", map[string]int64{"petta": 12345678, "blee1": 87654321}, true},
-				{"empty key", map[string]int64{"": 12345678}, false},
-				{"no value key", map[string]int64{"<no value>": 87654321}, false},
-				{"empty map", map[string]int64{}, false},
-			}
-
-			for _, tc := range testCases {
-				t.Run(tc.name, func(t *testing.T) {
-					assert.Equal(t, tc.expect, validateMap(tc.input), "Test case: %s", tc.name)
-				})
-			}
-		})
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Equal(t, tc.expect, validateMap(tc.input), "Test case: %s", tc.name)
+			})
+		}
+	})
 }

--- a/splunk/Dockerfile
+++ b/splunk/Dockerfile
@@ -9,7 +9,7 @@ COPY --chmod=777 tests/indexes.conf /opt/splunk/etc/apps/search/local/indexes.co
 COPY --chmod=777 scripts/log_indexing.sh /opt/splunk/log_indexing.sh
 COPY --chmod=777 scripts/pre-run.sh /opt/splunk/pre-run.sh
 
-RUN microdnf install -y jq \
+RUN microdnf install -y jq --disablerepo="*" --enablerepo="ubi-8-appstream-rpms" \
     && microdnf clean all \
     && umask 000 \
     && touch "/opt/splunk/output.log"
@@ -28,7 +28,7 @@ USER root
 
 RUN mkdir -p /opt/splunk/var/lib/splunk
 COPY --chmod=777 --from=builder /opt/splunk/etc/apps/search/local/indexes.conf /opt/splunk/etc/apps/search/local/indexes.conf
-COPY --chmod=777 --from=builder /var/splunk_buildtime_db/splunk /opt/splunk/var/lib/splunk/
+COPY --chmod=777 --from=builder /var/splunk_buildtime_db/splunk/ /opt/splunk/var/lib/splunk/
 
 ENV SPLUNKD_SSL_ENABLE=false
 

--- a/splunk/scripts/pre-run.sh
+++ b/splunk/scripts/pre-run.sh
@@ -21,9 +21,12 @@ done
 # Index the logs required for the tests
 bash /opt/splunk/log_indexing.sh
 
+# Wait an extra 10 seconds to assure completion of logs ingestion (fix flakiness)
+sleep 10
+
 # Copy the whole Splunk DB to an accessible directory
-sudo mkdir -p /var/splunk_buildtime_db/splunk
-sudo cp -r /opt/splunk/var/lib/splunk/ /var/splunk_buildtime_db/splunk
+sudo mkdir -p /var/splunk_buildtime_db
+sudo cp -r /opt/splunk/var/lib/splunk/ /var/splunk_buildtime_db
 
 # Shut down the Splunk service
 sudo -u splunk /opt/splunk/bin/splunk stop

--- a/splunk/splunk_test.go
+++ b/splunk/splunk_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/redhat-appstudio/segment-bridge.git/containerfixture"
-
+	"github.com/redhat-appstudio/segment-bridge.git/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,11 +21,12 @@ var countPattern = regexp.MustCompile(`(?m)^count\s+(\d+)$`)
 const NotUpErrorMsg = "The %s instance is not up, cannot verify indexing for tests."
 
 func withSplunkContainer(t *testing.T, testFunc func(containerfixture.FixtureInfo)) {
+	filepath, _ := utils.GetCallerFileDirPath(1)
 	containerfixture.WithServiceContainer(
-		t, splunkServiceManifest,
+		t, "splunk", filepath, splunkServiceManifest,
 		func(fi containerfixture.FixtureInfo) {
 			endpoint := fmt.Sprintf("http://localhost:%s/%s", fi.ApiPort, ServiceStatusCheckPath)
-			containerfixture.RequireServiceIsUp(t, endpoint, ServiceName, NotUpErrorMsg)
+			containerfixture.RequireServiceIsUp(t, endpoint, NotUpErrorMsg, ServiceName)
 			testFunc(fi)
 		})
 }


### PR DESCRIPTION
# Description

The Splunk container had a few issues that caused flakiness:

- The second stage of the dockerfile did not always finished copying
the DB (digested logs) before finishing the build process, leading
to failures.
- `podman kube play` also seems to cause instability when building
the image.

This change solve those issues by:
1. Add a 10 second wait time between copying the Splunk DB
and finishing the build process; for now, it seems to be enough
time for the process to complete consecutively.
2. Change the test framework so instead of relaying on `podman kube play`
for both building and running the container, the framework will build
using `podman build`, and run the container with `podman kube play`
using the built image.


## Issue ticket number and link
[RHTAPWATCH-522](https://issues.redhat.com/browse/RHTAPWATCH-522)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Manually building the container using `podman play kube`
- Manually building the container using `podman build` for the build process, and `podman play kube` for running the container.
- Running the container using the automated splunk tests


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
