### PR TITLE
chore(RHTAPWATCH-386): events for PR originated build PipelineRuns

### DIFF
--- a/querygen/querygen.go
+++ b/querygen/querygen.go
@@ -34,7 +34,8 @@ func GenBuildPipelineRunCreatedQuery(index string) string {
 				`"responseObject.metadata.resourceVersion"="*"`,
 		).
 		WithEventExpr(`"Build PipelineRun created"`).
-		WithFields("namespace", "application", "component", "repo", "commit_sha", "target_branch").
+		WithFields("namespace", "application", "component", "repo", "commit_sha", "target_branch",
+			"git_trigger_event_type", "git_trigger_provider", "pipeline_log_url").
 		String()
 	return q
 }
@@ -59,7 +60,8 @@ func GenBuildPipelineRunStartedQuery(index string) string {
 		).
 		WithFilter(statusFilter).
 		WithEventExpr(`"Build PipelineRun started"`).
-		WithFields("namespace", "application", "component").
+		WithFields("namespace", "application", "component",
+			"git_trigger_event_type", "git_trigger_provider", "pipeline_log_url").
 		String()
 	return q
 }
@@ -130,7 +132,8 @@ func GenBuildPipelineRunCompletedQuery(index string) string {
 			"namespace", "application", "component",
 			"status_message", "status_reason",
 			"repo", "commit_sha", "target_branch",
-		).
+			"git_trigger_event_type", "git_trigger_provider",
+			 "pipeline_log_url").
 		String()
 
 	return q

--- a/querygen/ujquery.go
+++ b/querygen/ujquery.go
@@ -75,6 +75,18 @@ func NewUserJourneyQuery(index string) *UserJourneyQuery {
 				subObj:    "properties",
 				srcFields: []string{"responseObject.metadata.annotations.build.appstudio.redhat.com/target_branch"},
 			},
+			"git_trigger_event_type": {
+				subObj:    "properties",
+				srcFields: []string{"responseObject.metadata.annotations.pipelinesascode.tekton.dev/event-type"},
+			},
+			"git_trigger_provider": {
+				subObj:    "properties",
+				srcFields: []string{"responseObject.metadata.annotations.pipelinesascode.tekton.dev/git-provider"},
+			},
+			"pipeline_log_url": {
+				subObj:    "properties",
+				srcFields: []string{"responseObject.metadata.annotations.pipelinesascode.tekton.dev/log-url"},
+			},
 			"vulnerabilities_critical": {
 				subObj:    "properties",
 				srcFields: []string{"clair_scan_result.vulnerabilities.critical"},


### PR DESCRIPTION
Producing a segment event whenever a build PipelineRun is originated from a PR, which means it was triggered by a webhook or by a change to a PR.