### PR TITLE
refator(RHTAPWATCH-547): Per-K8s API field sets

### DIFF
--- a/querygen/k8s_audit_fieldset.go
+++ b/querygen/k8s_audit_fieldset.go
@@ -1,0 +1,45 @@
+package querygen
+
+import (
+	"fmt"
+	"strings"
+)
+
+// K8sApiId defines a K8s API by including details about the API group and
+// resource names
+type K8sApiId struct {
+	apiGroup string
+	resource string
+}
+
+// Maps K8s API identifiers to field sets. This map should at least contain
+// a value for the K8sApiId zero value. That value is used as the FieldSet for
+// querying. When querying for an API object for which a value exists in the map
+// the fields in the value are added to the zero-value fields to make up the
+// final FieldSet used for the query.
+// This allows to have different field settings for different K8s APIs.
+type K8sAuditFieldSet map[K8sApiId]FieldSet
+
+func (kfs K8sAuditFieldSet) QueryGen(
+	index string, api K8sApiId, searchExpr string, fields []string,
+) (string, error) {
+	searchCmd := strings.TrimSpace(fmt.Sprintf(
+		`search index="%s" log_type=audit ` +
+		`"objectRef.apiGroup"="%s" ` +
+		`"objectRef.resource"="%s" ` +
+		`%s`,
+		index,
+		api.apiGroup,
+		api.resource,
+		searchExpr,
+	))
+	fieldSet := FieldSet{}
+	for _, apiId := range []K8sApiId{{}, api} {
+		fieldSetToAdd := kfs[apiId]
+		for fld, spec := range fieldSetToAdd {
+			fieldSet[fld] = spec
+		}
+	}
+
+	return fieldSet.QueryGen(searchCmd, fields)
+}

--- a/querygen/k8s_audit_fieldset.go
+++ b/querygen/k8s_audit_fieldset.go
@@ -21,7 +21,7 @@ type K8sApiId struct {
 type K8sAuditFieldSet map[K8sApiId]FieldSet
 
 func (kfs K8sAuditFieldSet) QueryGen(
-	index string, api K8sApiId, searchExpr string, fields []string,
+	index string, api K8sApiId, searchExpr string, fields []string, extra ...FieldSet,
 ) (string, error) {
 	searchCmd := strings.TrimSpace(fmt.Sprintf(
 		`search index="%s" log_type=audit ` +
@@ -33,9 +33,10 @@ func (kfs K8sAuditFieldSet) QueryGen(
 		api.resource,
 		searchExpr,
 	))
+	allFieldSets := []FieldSet{kfs[K8sApiId{}], kfs[api]}
+	allFieldSets = append(allFieldSets, extra...)
 	fieldSet := FieldSet{}
-	for _, apiId := range []K8sApiId{{}, api} {
-		fieldSetToAdd := kfs[apiId]
+	for _, fieldSetToAdd := range allFieldSets {
 		for fld, spec := range fieldSetToAdd {
 			fieldSet[fld] = spec
 		}

--- a/querygen/k8s_audit_fieldset_test.go
+++ b/querygen/k8s_audit_fieldset_test.go
@@ -1,0 +1,73 @@
+package querygen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestK8sAuditFieldSet_QueryGen(t *testing.T) {
+	kfs := K8sAuditFieldSet{
+		K8sApiId{}: {
+			"plain_field":  {},
+			"override_field": {},
+		},
+		K8sApiId{"api1.com", "SomeObj"}: {
+			"override_field": {srcFields: []string{"other_field"}},
+		},
+	}
+	fields := []string{"plain_field", "override_field"}
+	includeFieldsCmd := `fields override_field,plain_field`
+	type args struct {
+		index      string
+		api        K8sApiId
+		searchExpr string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Simple query",
+			args: args{
+				index: "some_idx",
+				api: K8sApiId{"other.api.com", "SomeOtherObj"},
+				searchExpr: "foo bar baz",
+			},
+			want: `search index="some_idx" log_type=audit ` +
+				`"objectRef.apiGroup"="other.api.com" `+
+				`"objectRef.resource"="SomeOtherObj" ` +
+				`foo bar baz` +
+				`|` + includeFieldsCmd +
+				`|` + excludeFieldsCmd,
+		},
+		{
+			name: "Query on customized object",
+			args: args{
+				index: "some_idx",
+				api: K8sApiId{"api1.com", "SomeObj"},
+				searchExpr: "foo bar baz",
+			},
+			want: `search index="some_idx" log_type=audit ` +
+				`"objectRef.apiGroup"="api1.com" `+
+				`"objectRef.resource"="SomeObj" ` +
+				`foo bar baz` +
+				`|eval override_field='other_field'` +
+				`|` + includeFieldsCmd +
+				`|` + excludeFieldsCmd,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := kfs.QueryGen(tt.args.index, tt.args.api, tt.args.searchExpr, fields)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/querygen/querygen.go
+++ b/querygen/querygen.go
@@ -7,12 +7,10 @@ import "fmt"
 // GenApplicationQuery returns a Splunk query for generating Segment events
 // representing AppStudio Application object events.
 func GenApplicationQuery(index string) string {
-	q, _ := NewUserJourneyQuery(index).
+	q, _ := NewUserJourneyQuery(index, K8sApiId{"appstudio.redhat.com","applications"}).
 		WithPredicate(
 			`verb=create `+
 				`"responseStatus.code" IN (200, 201) `+
-				`"objectRef.apiGroup"="appstudio.redhat.com" `+
-				`"objectRef.resource"="applications" `+
 				`("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*")) `+
 				`(verb!=create OR "responseObject.metadata.resourceVersion"="*")`,
 		).
@@ -24,12 +22,10 @@ func GenApplicationQuery(index string) string {
 // GenComponentQuery returns a Splunk query for generating Segment events
 // representing AppStudio Component object events.
 func GenComponentQuery(index string) string {
-	q, _ := NewUserJourneyQuery(index).
+	q, _ := NewUserJourneyQuery(index, K8sApiId{"appstudio.redhat.com","components"}).
 		WithPredicate(
 			`verb IN (create, update, delete, patch) `+
 				`"responseStatus.code" IN (200, 201) `+
-				`"objectRef.apiGroup"="appstudio.redhat.com" `+
-				`"objectRef.resource"="components" `+
 				`("impersonatedUser.username"="*" OR (user.username="*" AND NOT user.username="system:*")) `+
 				`(verb!=create OR "responseObject.metadata.resourceVersion"="*")`,
 		).
@@ -41,12 +37,10 @@ func GenComponentQuery(index string) string {
 // GenBuildPipelineRunCreatedQuery returns a Splunk query for generating Segment events
 // representing creation of AppStudio build PipelineRuns.
 func GenBuildPipelineRunCreatedQuery(index string) string {
-	q, _ := NewUserJourneyQuery(index).
+	q, _ := NewUserJourneyQuery(index, K8sApiId{"tekton.dev","pipelineruns"}).
 		WithPredicate(
 			`verb=create `+
 				`"responseStatus.code" IN (200, 201) `+
-				`"objectRef.apiGroup"="tekton.dev" `+
-				`"objectRef.resource"="pipelineruns" `+
 				`"responseObject.metadata.labels.pipelines.appstudio.openshift.io/type"=build `+
 				`"responseObject.metadata.resourceVersion"="*"`,
 		).
@@ -64,12 +58,10 @@ func GenBuildPipelineRunStartedQuery(index string) string {
 	statusFilter.opts.reasons = []string{"Running"}
 	statusFilter.opts.message = "Tasks Completed: 0 %"
 
-	q, _ := NewUserJourneyQuery(index).
+	q, _ := NewUserJourneyQuery(index, K8sApiId{"tekton.dev","pipelineruns"}).
 		WithPredicate(
 			`verb=update `+
 				`"responseStatus.code"=200 `+
-				`"objectRef.apiGroup"="tekton.dev" `+
-				`"objectRef.resource"="pipelineruns" `+
 				`"objectRef.subresource"="status" `+
 				`"responseObject.metadata.labels.pipelines.appstudio.openshift.io/type"=build `+
 				`"responseObject.metadata.resourceVersion"="*" `+
@@ -92,12 +84,10 @@ func GenClairScanCompletedQuery(index string) string {
 
 	trFilter := NewTektonTaskResultFilter("CLAIR_SCAN_RESULT")
 
-	q, _ := NewUserJourneyQuery(index).
+	q, _ := NewUserJourneyQuery(index, K8sApiId{"tekton.dev","taskruns"}).
 		WithPredicate(
 			`verb=update `+
 				`"responseStatus.code"=200 `+
-				`"objectRef.apiGroup"="tekton.dev" `+
-				`"objectRef.resource"="taskruns" `+
 				`"objectRef.subresource"="status" `+
 				`"requestObject.metadata.labels.tekton.dev/pipelineTask"="clair-scan" `+
 				`"responseObject.status.completionTime"="*"`,
@@ -127,12 +117,10 @@ func GenBuildPipelineRunCompletedQuery(index string) string {
 	statusFilter := NewStatusConditionFilter("Succeeded")
 	statusFilter.opts.reasons = []string{"Completed", "Failed"}
 
-	q, _ := NewUserJourneyQuery(index).
+	q, _ := NewUserJourneyQuery(index, K8sApiId{"tekton.dev","pipelineruns"}).
 		WithPredicate(
 			`verb=update `+
 				`"responseStatus.code"=200 `+
-				`"objectRef.apiGroup"="tekton.dev" `+
-				`"objectRef.resource"="pipelineruns" `+
 				`"objectRef.subresource"="status" `+
 				`"responseObject.metadata.labels.pipelines.appstudio.openshift.io/type"=build `+
 				`"responseObject.metadata.resourceVersion"="*" `+
@@ -157,12 +145,10 @@ func GenReleaseCompletedQuery(index string) string {
 	statusFilter := NewStatusConditionFilter("Released")
 	statusFilter.opts.reasons = []string{"Succeeded", "Failed"}
 
-	q, _ := NewUserJourneyQuery(index).
+	q, _ := NewUserJourneyQuery(index, K8sApiId{"appstudio.redhat.com","releases"}).
 		WithPredicate(
 			`verb=patch `+
 				`"responseStatus.code"=200 `+
-				`"objectRef.apiGroup"="appstudio.redhat.com" `+
-				`"objectRef.resource"="releases" `+
 				`"objectRef.subresource"="status" `+
 				`"responseObject.metadata.resourceVersion"="*" `+
 				`"responseObject.status.completionTime"="*"`,
@@ -177,12 +163,10 @@ func GenReleaseCompletedQuery(index string) string {
 // GenPullRequestCreatedQuery returns a Splunk query for generating Segment events
 // whenever a Pull request is created in the users GitHub repository.
 func GenPullRequestCreatedQuery(index string) string {
-	q, _ := NewUserJourneyQuery(index).
+	q, _ := NewUserJourneyQuery(index, K8sApiId{"appstudio.redhat.com","components"}).
 		WithPredicate(
 			`verb=update `+
 				`"responseStatus.code"=200 `+
-				`"objectRef.apiGroup"="appstudio.redhat.com" `+
-				`"objectRef.resource"="components" `+
 				`"user.username"="system:serviceaccount:build-service:build-service-controller-manager" `+
 				`"responseObject.metadata.annotations.build.appstudio.openshift.io/status"="*pac*" `+
 				`(NOT "responseObject.metadata.annotations.build.appstudio.openshift.io/request"="*")`,

--- a/querygen/ujquery.go
+++ b/querygen/ujquery.go
@@ -1,15 +1,112 @@
 package querygen
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 )
+
+var UJFieldSet = K8sAuditFieldSet{
+	K8sApiId{}: {
+		"messageId":     {srcFields: []string{"auditID"}},
+		"timestamp":     {srcFields: []string{"requestReceivedTimestamp"}},
+		"type":          {srcExpr: `"track"`},
+		"userAgent":     {subObj: "context"},
+		"userId":        {srcFields: []string{"impersonatedUser.username", "user.username"}},
+		"namespace":     {srcFields: []string{"objectRef.namespace"}},
+		"event_verb":    {srcFields: []string{"verb"}},
+		"event_subject": {srcFields: []string{"objectRef.resource"}},
+		"apiGroup":      {subObj: "properties", srcFields: []string{"objectRef.apiGroup"}},
+		"apiVersion":    {subObj: "properties", srcFields: []string{"objectRef.apiVersion"}},
+		"kind":          {subObj: "properties", srcFields: []string{"objectRef.resource"}},
+		"name":          {subObj: "properties", srcFields: []string{"objectRef.name"}},
+		"src_url":       {subObj: "properties", srcFields: []string{"responseObject.spec.source.git.url"}},
+		"src_revision":  {subObj: "properties", srcFields: []string{"responseObject.spec.source.git.revision"}},
+		"src_context":   {subObj: "properties", srcFields: []string{"responseObject.spec.source.git.context"}},
+		"application": {
+			subObj: "properties",
+			srcFields: []string{
+				"responseObject.spec.application",
+				"responseObject.metadata.labels.appstudio.openshift.io/application",
+			},
+		},
+		"commit_sha": {
+			subObj:    "properties",
+			srcFields: []string{"responseObject.metadata.annotations.build.appstudio.redhat.com/commit_sha"},
+		},
+		"component": {
+			subObj: "properties",
+			srcFields: []string{
+				"responseObject.spec.componentName",
+				"responseObject.metadata.labels.appstudio.openshift.io/component",
+			},
+		},
+		"repo": {
+			subObj:    "properties",
+			srcFields: []string{"responseObject.metadata.annotations.build.appstudio.openshift.io/repo"},
+			srcExpr:   `replace('responseObject.metadata.annotations.build.appstudio.openshift.io/repo',"^([^?]*)(.*)?","\1")`,
+		},
+		"target_branch": {
+			subObj:    "properties",
+			srcFields: []string{"responseObject.metadata.annotations.build.appstudio.redhat.com/target_branch"},
+		},
+		"git_trigger_event_type": {
+			subObj:    "properties",
+			srcFields: []string{"responseObject.metadata.annotations.pipelinesascode.tekton.dev/event-type"},
+		},
+		"git_trigger_provider": {
+			subObj:    "properties",
+			srcFields: []string{"responseObject.metadata.annotations.pipelinesascode.tekton.dev/git-provider"},
+		},
+		"pipeline_log_url": {
+			subObj:    "properties",
+			srcFields: []string{"responseObject.metadata.annotations.pipelinesascode.tekton.dev/log-url"},
+		},
+		"vulnerabilities_critical": {
+			subObj:    "properties",
+			srcFields: []string{"clair_scan_result.vulnerabilities.critical"},
+		},
+		"vulnerabilities_high": {
+			subObj:    "properties",
+			srcFields: []string{"clair_scan_result.vulnerabilities.high"},
+		},
+		"vulnerabilities_medium": {
+			subObj:    "properties",
+			srcFields: []string{"clair_scan_result.vulnerabilities.medium"},
+		},
+		"vulnerabilities_low": {
+			subObj:    "properties",
+			srcFields: []string{"clair_scan_result.vulnerabilities.low"},
+		},
+		"merge_url": {
+			subObj:    "properties",
+			srcFields: []string{"build_status.pac.merge-url"},
+		},
+	},
+	K8sApiId{"appstudio.redhat.com","components"}: {
+		"event_verb":    {
+			srcExpr: `case(
+				'objectRef.resource'=="components"
+				AND verb=="patch"
+				AND spath(_raw,"requestObject{0}.path")=="/metadata/annotations/build.appstudio.openshift.io~1request",
+				spath(_raw, "requestObject{0}.value"),
+				'objectRef.resource'=="components"
+				AND verb=="patch"
+				AND NOT isnull('requestObject.metadata.annotations.build.appstudio.openshift.io/request'),
+				'requestObject.metadata.annotations.build.appstudio.openshift.io/request',
+				true(),
+				'verb'
+				)`,
+		},
+	},
+}
 
 // UserJourneyQuery is a builder for Splunk queries.
 type UserJourneyQuery struct {
 	// The Splunk index to be searched
 	index string
+
+	// The K8s API objects to be searched
+	subject K8sApiId
 
 	// The initial search predicate used to narrow down results
 	predicate string
@@ -21,15 +118,15 @@ type UserJourneyQuery struct {
 	// Fields to return from the query
 	fields []string
 
-	// A FieldSet containing all possible output fields for the query. If a Filter
-	// is used, its FieldSet is merged with the default set.
-	fieldset FieldSet
+	// FieldSet objects contributed to the query by filters
+	filterFieldSets []FieldSet
 }
 
 // NewUserJourneyQuery constructs a default UserJourneyQuery
-func NewUserJourneyQuery(index string) *UserJourneyQuery {
+func NewUserJourneyQuery(index string, subject K8sApiId) *UserJourneyQuery {
 	return &UserJourneyQuery{
 		index: index,
+		subject: subject,
 		fields: []string{
 			"apiGroup",
 			"apiVersion",
@@ -41,95 +138,6 @@ func NewUserJourneyQuery(index string) *UserJourneyQuery {
 			"timestamp",
 			"type",
 			"userAgent",
-		},
-		fieldset: FieldSet{
-			"messageId":     {srcFields: []string{"auditID"}},
-			"timestamp":     {srcFields: []string{"requestReceivedTimestamp"}},
-			"type":          {srcExpr: `"track"`},
-			"userAgent":     {subObj: "context"},
-			"userId":        {srcFields: []string{"impersonatedUser.username", "user.username"}},
-			"namespace":     {srcFields: []string{"objectRef.namespace"}},
-			"event_verb":    {
-				srcExpr: `case(
-					'objectRef.resource'=="components"
-					AND verb=="patch"
-					AND spath(_raw,"requestObject{0}.path")=="/metadata/annotations/build.appstudio.openshift.io~1request",
-					spath(_raw, "requestObject{0}.value"),
-					'objectRef.resource'=="components"
-					AND verb=="patch"
-					AND NOT isnull('requestObject.metadata.annotations.build.appstudio.openshift.io/request'),
-					'requestObject.metadata.annotations.build.appstudio.openshift.io/request',
-					true(),
-					'verb'
-					)`,
-			},
-			"event_subject": {srcFields: []string{"objectRef.resource"}},
-			"apiGroup":      {subObj: "properties", srcFields: []string{"objectRef.apiGroup"}},
-			"apiVersion":    {subObj: "properties", srcFields: []string{"objectRef.apiVersion"}},
-			"kind":          {subObj: "properties", srcFields: []string{"objectRef.resource"}},
-			"name":          {subObj: "properties", srcFields: []string{"objectRef.name"}},
-			"src_url":       {subObj: "properties", srcFields: []string{"responseObject.spec.source.git.url"}},
-			"src_revision":  {subObj: "properties", srcFields: []string{"responseObject.spec.source.git.revision"}},
-			"src_context":   {subObj: "properties", srcFields: []string{"responseObject.spec.source.git.context"}},
-			"application": {
-				subObj: "properties",
-				srcFields: []string{
-					"responseObject.spec.application",
-					"responseObject.metadata.labels.appstudio.openshift.io/application",
-				},
-			},
-			"commit_sha": {
-				subObj:    "properties",
-				srcFields: []string{"responseObject.metadata.annotations.build.appstudio.redhat.com/commit_sha"},
-			},
-			"component": {
-				subObj: "properties",
-				srcFields: []string{
-					"responseObject.spec.componentName",
-					"responseObject.metadata.labels.appstudio.openshift.io/component",
-				},
-			},
-			"repo": {
-				subObj:    "properties",
-				srcFields: []string{"responseObject.metadata.annotations.build.appstudio.openshift.io/repo"},
-				srcExpr:   `replace('responseObject.metadata.annotations.build.appstudio.openshift.io/repo',"^([^?]*)(.*)?","\1")`,
-			},
-			"target_branch": {
-				subObj:    "properties",
-				srcFields: []string{"responseObject.metadata.annotations.build.appstudio.redhat.com/target_branch"},
-			},
-			"git_trigger_event_type": {
-				subObj:    "properties",
-				srcFields: []string{"responseObject.metadata.annotations.pipelinesascode.tekton.dev/event-type"},
-			},
-			"git_trigger_provider": {
-				subObj:    "properties",
-				srcFields: []string{"responseObject.metadata.annotations.pipelinesascode.tekton.dev/git-provider"},
-			},
-			"pipeline_log_url": {
-				subObj:    "properties",
-				srcFields: []string{"responseObject.metadata.annotations.pipelinesascode.tekton.dev/log-url"},
-			},
-			"vulnerabilities_critical": {
-				subObj:    "properties",
-				srcFields: []string{"clair_scan_result.vulnerabilities.critical"},
-			},
-			"vulnerabilities_high": {
-				subObj:    "properties",
-				srcFields: []string{"clair_scan_result.vulnerabilities.high"},
-			},
-			"vulnerabilities_medium": {
-				subObj:    "properties",
-				srcFields: []string{"clair_scan_result.vulnerabilities.medium"},
-			},
-			"vulnerabilities_low": {
-				subObj:    "properties",
-				srcFields: []string{"clair_scan_result.vulnerabilities.low"},
-			},
-			"merge_url": {
-				subObj:    "properties",
-				srcFields: []string{"build_status.pac.merge-url"},
-			},
 		},
 	}
 }
@@ -150,9 +158,7 @@ func (q *UserJourneyQuery) WithCommands(commands ...string) *UserJourneyQuery {
 // WithFilter adds all the Splunk commands for a Filter to the query.
 // Each call appends to the existing set of commands so order of invocation is important.
 func (q *UserJourneyQuery) WithFilter(filter Filter) *UserJourneyQuery {
-	for k, v := range filter.FieldSet() {
-		q.fieldset[k] = v
-	}
+	q.filterFieldSets = append(q.filterFieldSets, filter.FieldSet())
 	return q.WithCommands(filter.Commands()...)
 }
 
@@ -165,7 +171,10 @@ func (q *UserJourneyQuery) WithFields(fields ...string) *UserJourneyQuery {
 // WithEventExpr adds a Splunk 'eval' expression specifically for the 'event' output field.
 // This is handy when trying to override the default event naming logic.
 func (q *UserJourneyQuery) WithEventExpr(expr string) *UserJourneyQuery {
-	q.fieldset["event"] = &FieldSetSpec{srcExpr: expr}
+	q.filterFieldSets = append(
+		q.filterFieldSets,
+		FieldSet{"event": {srcExpr: expr}},
+	)
 	q.fields = append(q.fields, "event")
 	return q
 }
@@ -174,11 +183,8 @@ func (q *UserJourneyQuery) WithEventExpr(expr string) *UserJourneyQuery {
 func (q *UserJourneyQuery) String() (string, error) {
 	sort.Strings(q.fields) // To make test results predictable
 
-	searchCmd := strings.TrimSpace(fmt.Sprintf(
-		`search index="%s" log_type=audit %s`, q.index, q.predicate,
-	))
-	commands := append([]string{searchCmd}, q.commands...)
+	commands := append([]string{q.predicate}, q.commands...)
 	query := strings.Join(commands, " | ")
 
-	return q.fieldset.QueryGen(query, q.fields)
+	return UJFieldSet.QueryGen(q.index, q.subject, query, q.fields, q.filterFieldSets...)
 }

--- a/querygen/ujquery_test.go
+++ b/querygen/ujquery_test.go
@@ -20,7 +20,7 @@ func (f *TestFilter) Commands() []string {
 }
 
 func TestUserJourneyQuery(t *testing.T) {
-	q, err := NewUserJourneyQuery("idx").
+	q, err := NewUserJourneyQuery("idx", K8sApiId{"api1.com","objects"}).
 		WithPredicate("verb=created").
 		WithEventExpr(`"Event Name"`).
 		WithCommands(`eval foo="bar"`).
@@ -29,7 +29,9 @@ func TestUserJourneyQuery(t *testing.T) {
 		String()
 	assert.Nil(t, err)
 	assert.Equal(t,
-		`search index="idx" log_type=audit verb=created `+
+		`search index="idx" log_type=audit ` +
+			`"objectRef.apiGroup"="api1.com" "objectRef.resource"="objects" ` +
+			`verb=created `+
 			`| eval foo="bar" `+
 			`| eval tf1="hello" `+
 			`| eval tf2="world"`+
@@ -37,6 +39,7 @@ func TestUserJourneyQuery(t *testing.T) {
 			`event_subject='objectRef.resource',`+
 			`event_verb='verb',`+
 			`messageId='auditID',`+
+			`namespace='objectRef.namespace',`+
 			`tf1='tf1',`+
 			`tf2='tf2',`+
 			`timestamp='requestReceivedTimestamp',`+
@@ -58,6 +61,6 @@ func TestUserJourneyQuery(t *testing.T) {
 }
 
 func TestUserJourneyQueryUnknownField(t *testing.T) {
-	_, err := NewUserJourneyQuery("idx").WithFields("not-found").String()
+	_, err := NewUserJourneyQuery("idx", K8sApiId{"api1.com","objects"}).WithFields("not-found").String()
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Introduce a new K8sAuditFieldSet object built on top of our exiting FieldSet object, but specialized for queries against the audit log. A key feature is the ability to specify different field settings for different K8s resource types. This will make it easier to have common output fields that require different ways to calculate them for different resources.

As part of the work here, introduced the new object type and re-factored UserJourneyQuery to use it.