### PR TITLE
chore(RHTAPWATCH-509): run shellcheck for opened PR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,7 @@ repos:
       - id: yamllint
     repo: https://github.com/adrienverge/yamllint
     rev: v1.29.0
+  - hooks:
+      - id: shellcheck
+    repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.6

--- a/scripts/fetch-uj-records.sh
+++ b/scripts/fetch-uj-records.sh
@@ -45,7 +45,7 @@ if command -v querygen > /dev/null; then
 elif command -v go > /dev/null; then
   QUERYGEN="go run $GO_PACKAGE/cmd/querygen"
 else
-  echo 'Couldn`t find the querygen binary or go in $PATH' 1>&2
+  echo "Couldn\`t find the querygen binary or go in $PATH" 1>&2
   exit 127
 fi
 

--- a/scripts/segment-mass-uploader.sh
+++ b/scripts/segment-mass-uploader.sh
@@ -9,7 +9,7 @@ set -o pipefail -o errexit -o nounset
 # Add script file directory to PATH so we can use other scripts in the same
 # directory
 SELFDIR="$(dirname "$0")"
-PATH="$SELFDIR:${PATH#$SELFDIR:}"
+PATH="$SELFDIR:${PATH#"$SELFDIR":}"
 
 # ======= Parameters ======
 # The following variables can be set from outside the script by setting

--- a/scripts/segment-uploader.sh
+++ b/scripts/segment-uploader.sh
@@ -11,7 +11,7 @@ set -o pipefail -o errexit -o nounset
 # Add script file directory to PATH so we can use other scripts in the same
 # directory
 SELFDIR="$(dirname "$0")"
-PATH="$SELFDIR:${PATH#$SELFDIR:}"
+PATH="$SELFDIR:${PATH#"$SELFDIR":}"
 
 # ======= Parameters ======
 # The following variables can be set from outside the script by setting

--- a/splunk/scripts/pre-run.sh
+++ b/splunk/scripts/pre-run.sh
@@ -3,12 +3,12 @@
 export SPLUNK_PASSWORD="Password"
 
 # Run an instance of Splunk during the build, to prepare the indexed logs for the tests
-/sbin/entrypoint.sh start-service >> $SPLUNK_HOME/output.log 2>&1 &
+/sbin/entrypoint.sh start-service >> "$SPLUNK_HOME"/output.log 2>&1 &
 
 # Make sure the Splunk service is up
 timeout_start=$(date +%s)
 while true; do
-    if grep -q "Ansible playbook complete" $SPLUNK_HOME/output.log; then
+    if grep -q "Ansible playbook complete" "$SPLUNK_HOME"/output.log; then
         break
     fi
     if [ "$(($(date +%s) - timeout_start))" -ge 120 ]; then


### PR DESCRIPTION
# Description
Adds a step to the pre-commit github workflow to run shellcheck linter
on every opened pull request.

## Issue ticket number and link
[RHTAPWATCH-509](https://issues.redhat.com/browse/RHTAPWATCH-509)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Running `pre-commit run --all-files` as well as the script's tests after formatting.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
