### PR TITLE
chore(RHTAPWATCH-200): automate dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+reviewers-common: &reviewers-common
+  reviewers:
+    - "ifireball"
+    - "omeramsc"
+    - "amisstea"
+    - "Kousalya1998"
+    - "srivickynesh"
+    - "hmariset"
+    - "ShakedAviv50313"
+    - "yftacherzog"
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(Dependabot-docker): "
+    <<: *reviewers-common
+  - package-ecosystem: "docker"
+    directory: "/splunk/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(Dependabot-docker): "
+    <<: *reviewers-common
+  - package-ecosystem: "docker"
+    directory: "/kwok/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(Dependabot-docker): "
+    <<: *reviewers-common
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(Dependabot-actions): "
+    <<: *reviewers-common
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(Dependabot-go): "
+    <<: *reviewers-common
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(Dependabot-pip): "
+    <<: *reviewers-common


### PR DESCRIPTION
# Description

Adds a Dependabot to github actions in order to automate dependency updates.

Dependabot will update the following:
- docker (all 3 dockerfiles in the repository)
- gomod (go)
- pip (python)
- github actions

## Issue ticket number and link
[RHTAPWATCH-200](https://issues.redhat.com/browse/RHTAPWATCH-200)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
YAML file was linted, cannot test locally besides in another repo.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
