### PR TITLE
chore(RHTAPWATCH-177): run gitlint on CI

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,5 +1,5 @@
 ---
-name: Pre-commit
+name: checks on Pull Request
 "on":
   push:
     branches:
@@ -23,7 +23,18 @@ jobs:
         run: pip install -r requirements.lock
       - name: Run pre-commit
         run: pre-commit run --all-files
-      - name: Run gitlint on the latest commit message
+  gitlint:
+    name: Run gitlint checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install Python dependencies
+        run: pip install -r requirements.lock
+      - name: Run gitlint on CI with pre-commit
         run: >-
-          pre-commit run gitlint --hook-stage commit-msg --commit-msg-filename
-          .git/COMMIT_EDITMSG
+          gitlint --commits origin/${{ github.event.pull_request.base.ref
+          }}..HEAD

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,15 @@
+[general]
+contrib=contrib-title-conventional-commits,contrib-body-requires-signed-off-by
+
+[title-max-length]
+line-length=72
+
+[body-max-line-length]
+line-length=72
+
+[body-first-line-empty]
+
+# Dependabot tends to generate lines that exceed the default 80 char limit.
+[ignore-by-author-name]
+regex=dependabot
+ignore=all

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,1 +1,2 @@
 pre-commit==3.5.0
+gitlint==0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pre-commit
+gitlint


### PR DESCRIPTION
# Description

Fix an issue where the pre-commit github action that runs gitlint skipped linting the commit message.

This was done by installing an additional pre-commit gitlint hook that is designed for ci specifically.


## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Running the pre-commit hook locally

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
