### PR TITLE
fix: dependabot configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,3 @@
-reviewers-common: &reviewers-common
-  reviewers:
-    - "ifireball"
-    - "omeramsc"
-    - "amisstea"
-    - "Kousalya1998"
-    - "srivickynesh"
-    - "hmariset"
-    - "ShakedAviv50313"
-    - "yftacherzog"
-
 version: 2
 updates:
   - package-ecosystem: "docker"
@@ -17,39 +6,33 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore(Dependabot-docker): "
-    <<: *reviewers-common
   - package-ecosystem: "docker"
     directory: "/splunk/"
     schedule:
       interval: daily
     commit-message:
       prefix: "chore(Dependabot-docker): "
-    <<: *reviewers-common
   - package-ecosystem: "docker"
     directory: "/kwok/"
     schedule:
       interval: daily
     commit-message:
       prefix: "chore(Dependabot-docker): "
-    <<: *reviewers-common
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore(Dependabot-actions): "
-    <<: *reviewers-common
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: daily
     commit-message:
       prefix: "chore(Dependabot-go): "
-    <<: *reviewers-common
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: daily
     commit-message:
       prefix: "chore(Dependabot-pip): "
-    <<: *reviewers-common

--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,13 @@
 # See the OWNERS docs: https://go.k8s.io/owners
+reviewers:
+- "ifireball"
+- "omeramsc"
+- "amisstea"
+- "Kousalya1998"
+- "srivickynesh"
+- "hmariset"
+- "ShakedAviv50313"
+- "yftacherzog"
 
 approvers:
 - ifireball


### PR DESCRIPTION
# Description

Seems like dependabot's configuration file does
not accept aliases. In order to avoid repeating the reviewers list multiple times across the file,
added a reviewers section under the OWNERS file instead.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
