### PR TITLE
chore: pre-commit running for the whole review process

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -7,6 +7,8 @@ name: Pre-commit
   pull_request:
     types:
       - opened
+      - reopened
+      - synchronize
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

This change makes it so instead running the pre-commit action only when a PR is created, it'll run when it is created, re-opened, or when it has any changes (new commits, push events, rebases)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
