### PR TITLE
fix: gitlint workflow runs on pull request only

### DIFF
--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -1,28 +1,12 @@
 ---
-name: checks on Pull Request
+name: gitlint checks on Pull Request
 "on":
-  push:
-    branches:
-      - main
   pull_request:
     types:
       - opened
       - reopened
       - synchronize
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - name: Install Python dependencies
-        run: pip install -r requirements.lock
-      - name: Run pre-commit
-        run: pre-commit run --all-files
   gitlint:
     name: Run gitlint checks
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request_and_push.yaml
+++ b/.github/workflows/pull_request_and_push.yaml
@@ -1,0 +1,25 @@
+---
+name: checks on Pull Request and push
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install Python dependencies
+        run: pip install -r requirements.lock
+      - name: Run pre-commit
+        run: pre-commit run --all-files


### PR DESCRIPTION
# Description

Separates gitlint from the workflow for pull-request and push, as it cannot and should not run on push.

The new workflow runs it only for the pull-request process itself.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
