### PR TITLE
chore: gitlint ignores bot users

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -9,7 +9,7 @@ line-length=72
 
 [body-first-line-empty]
 
-# Dependabot tends to generate lines that exceed the default 80 char limit.
+# Bot users tends to generate invalid commits.
 [ignore-by-author-name]
-regex=dependabot
+regex=(dependabot|red-hat-trusted-app-pipeline)
 ignore=all


### PR DESCRIPTION
# Description

gitlint now ignores commits made by dependabot and red-hat-trusted-app-pipeline as those are usually
invalid (either have long lines or do not sign off commits)

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ignored my own user and committed invalid commits, seeing they are skipped by gitlint.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
