### PR TITLE
fix: lint issues with splunk container template

### DIFF
--- a/kwok/kwok_container_template.tmpl
+++ b/kwok/kwok_container_template.tmpl
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ .PodName}}
+  name: {{ .PodName }}
 spec:
   containers:
     - image: kwok

--- a/splunk/splunk_container_template.tmpl
+++ b/splunk/splunk_container_template.tmpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: { { .PodName } }
+  name: {{ .PodName }}
 spec:
   containers:
     - args:
@@ -16,6 +16,6 @@ spec:
       name: splunk
       ports:
         - containerPort: 8000
-          hostPort: {{ .WebPort}}
+          hostPort: {{ .WebPort }}
         - containerPort: 8089
-          hostPort: {{ .ApiPort}}
+          hostPort: {{ .ApiPort }}


### PR DESCRIPTION
# Description

The recent linting of the repository left an error on `splunk_container_template`, leaving the pod's
"name" invalid and therefor it is not being filled as part of the template. this fix it.

## Issue ticket number and link
None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run the container before & after the fix, using podman and using the go tests.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
