### PR TITLE
chore: fix yamllint warning on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: "docker"


### PR DESCRIPTION
# Description

yamllint produce a warning on each and every PR
regarding a missing "---" at the beginning of
`dependabot.yml`. this change should rid us of the warning.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
