### PR TITLE
chore: error-handling for log indexing

### DIFF
--- a/splunk/scripts/log_indexing.sh
+++ b/splunk/scripts/log_indexing.sh
@@ -5,9 +5,14 @@ endpoint="https://localhost:8089/services/data/inputs/oneshot"
 SPLUNK_PASSWORD="Password"
 
 echo "Indexing logs..."
+max_retries=3
+
 for file in "$logs_path"/*; do
   echo "Indexing $file"
-  curl  --insecure --user admin:"$SPLUNK_PASSWORD" "$endpoint" --data name="$file" --data index="test_index"
+  if ! curl --insecure --user admin:"$SPLUNK_PASSWORD" --retry $max_retries --retry-max-time 60 "$endpoint" --data name="$file" --data index="test_index"; then
+    echo "Encountered an error while initiating indexing for $file. Max retry attempts reached. Exiting."
+    exit 1
+  fi
 done
 
 timeout_start=$(date +%s)


### PR DESCRIPTION
# Description

We encountered an edge-case in which the curl command that initiate the log indexing for Splunk silently fail. As the looping check we have later on only checks for indexing that already started, therefore ignoring what failed to begin.

This change will fail the script on the initiation of the log indexing, given an error will occur.

## Issue ticket number and link
None

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual test:
```
[1/2] STEP 10/10: RUN bash -o errexit /opt/splunk/pre-run.sh
Indexing logs...
Indexing /opt/splunk/test_logs/log_example.log
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: 
Encountered an error while initiating indexing for /opt/splunk/test_logs/log_example.log. Exiting.
Error: error building at STEP "RUN bash -o errexit /opt/splunk/pre-run.sh": error while running runtime: exit status 1
```

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
