### PR TITLE
chore(RHTAPWATCH-504\505): {uid, ws}-map-maker fail on connection errors

### DIFF
--- a/scripts/uid-map-maker-job.sh
+++ b/scripts/uid-map-maker-job.sh
@@ -11,6 +11,7 @@
 #
 set -o pipefail -o errexit -o nounset -o xtrace
 
-oc create configmap --dry-run=client -o yaml uid-map \
-  --from-file=uid-map.json=<(KUBECONFIG="$KUBECONFIG_SRC" get-uid-map.sh) \
-| oc apply -f -
+if ! oc create configmap --dry-run=client -o yaml uid-map \
+  --from-file=uid-map.json=<(KUBECONFIG="$KUBECONFIG_SRC" get-uid-map.sh) | oc apply -f -; then
+  echo "Error: Encountered an issue while applying the ConfigMap."
+fi

--- a/scripts/ws-map-maker-job.sh
+++ b/scripts/ws-map-maker-job.sh
@@ -11,6 +11,7 @@
 #
 set -o pipefail -o errexit -o nounset -o xtrace
 
-oc create configmap --dry-run=client -o yaml ws-map \
-  --from-file=ws-map.json=<(KUBECONFIG="$KUBECONFIG_SRC" get-workspace-map.sh) \
-| oc apply -f -
+if ! oc create configmap --dry-run=client -o yaml ws-map \
+  --from-file=ws-map.json=<(KUBECONFIG="$KUBECONFIG_SRC" get-workspace-map.sh) | oc apply -f -; then
+  echo "Error: Encountered an issue while applying the ConfigMap."
+fi


### PR DESCRIPTION
# Description

The uid-map-maker and ws-map-maker script ignored cases where
there was a connection failure. this change
aim to catch those failures and report them
for better visibility of the error.


## Issue ticket number and link
[RHTAPWATCH-504](https://issues.redhat.com/browse/RHTAPWATCH-504)
[RHTAPWATCH-505](https://issues.redhat.com/browse/RHTAPWATCH-505)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not fully tested yet.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
