### PR TITLE
chore: remove description title from PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,3 @@
-# Description
-
-Please include a summary of the changes and the related issue. Please also
-include relevant motivation and context. List any dependencies that are
-required for this change.
 
 ## Issue ticket number and link
 


### PR DESCRIPTION
Removes the "Description" title from the pull request template.
The idea beyond this change is that we are to expect description to be a part of the commit message anyway, meaning it'll be automatically added to the beginning of the pull request description anyway.

having the description title there just adds the need to manually move the text, which don't seem to happen much, creating confusing PR description.

## Issue ticket number and link
None

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not needed

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
