### PR TITLE
chore(RHTAPWATCH-208): Run GO unit tests for each opened PR

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,35 @@
+---
+name: Unit tests
+"on":
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.access.redhat.com/ubi8/go-toolset:1.19.13-2.1698062273
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Cache jq
+        id: cache-jq
+        uses: actions/cache@v3
+        with:
+          path: ~/packages
+          key: jq-1.7-${{ runner.os }}
+        if: success()
+      - if: ${{ steps.cache-jq.outputs.cache-hit != 'true' }}
+        name: Install jq
+        run: |
+          mkdir -p ~/packages && \
+          curl -L \
+          https://github.com/stedolan/jq/releases/download/jq-1.7/jq-linux64 \
+          -o ~/packages/jq && \
+          chmod +x ~/packages/jq
+      - name: Run GO tests
+        run: |
+          export PATH=~/packages:$PATH && \
+          go test -short -v $(go list ./... | grep -v '/splunk\|/kwok')


### PR DESCRIPTION
Adds a new GH actions workflow that runs the GO unit tests on each opened pull request.

This excludes the kwok and splunk packages tests, as those include deployment of containers, which we don't want the GH actions container to deal with.

This is also made into a new PR-only workflow to allow for the future addition of codecov.


## Issue ticket number and link
[RHTAPWATCH-208](https://issues.redhat.com/browse/RHTAPWATCH-208)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Running the unit tests locally with the command used in the workflow.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
