### PR TITLE
chore(RHTAPWATCH-394): data gap fix for UJ job resync

### DIFF
--- a/deploy/data-gap-fix-job.yaml
+++ b/deploy/data-gap-fix-job.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: segment-bridge-data-gap-fix
+spec:
+  template:
+    spec:
+      containers:
+        - command:
+            - main-job.sh
+          env:
+            - name: CURL_NETRC
+              value: /usr/local/etc/netrc/netrc
+            - name: KUBECONFIG
+              value: /usr/local/etc/kube-config/kube-config
+            - name: UID_MAP_FILE
+              value: /usr/local/etc/uid-map/uid-map.json
+            - name: WS_MAP_FILE
+              value: /usr/local/etc/ws-map/ws-map.json
+            - name: QUERY_EARLIEST_TIME
+              value: <n>hours
+              #  Replace <n> with the number of hours data is missing for
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/rhtap-o11y--runtime-int/segment-bridge-job
+          imagePullPolicy: Always
+          name: segment-bridge
+          tty: true
+          volumeMounts:
+            - mountPath: /usr/local/etc/netrc
+              name: netrc
+              readOnly: true
+            - mountPath: /usr/local/etc/kube-config
+              name: kube-config
+              readOnly: true
+            - mountPath: /usr/local/etc/uid-map
+              name: uid-map
+              readOnly: true
+            - mountPath: /usr/local/etc/ws-map
+              name: ws-map
+              readOnly: true
+      restartPolicy: Never
+      volumes:
+        - name: netrc
+          secret:
+            secretName: netrc
+        - name: kube-config
+          secret:
+            secretName: kube-config
+        - configMap:
+            name: uid-map
+          name: uid-map
+        - configMap:
+            name: ws-map
+          name: ws-map


### PR DESCRIPTION
Adds a job definition to use in case there's a need to manually resync the UJ job on MPAAS.
The job is virtually a copy of an existing one (job.yaml -> data-gap-fix-job.yaml) with a modification to the `QUERY_EARLIEST_TIME` value, to allow users to easily rerun a fix for the job without deep knowledge of how the job works.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Used the manifest to create a similar job in MPAAS

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
