### PR TITLE
Add job for checking the Go Toolset image

### DIFF
--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -1,5 +1,5 @@
 ---
-name: gitlint checks on Pull Request
+name: checks on Pull Request
 "on":
   pull_request:
     types:
@@ -22,3 +22,15 @@ jobs:
         run: >-
           gitlint --commits origin/${{ github.event.pull_request.base.ref
           }}..HEAD
+  check-same-go-toolset:
+    name: Check the same Go Toolset image is used everywhere
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run check-same-go-toolset script
+        run: >-
+          bash chore-scripts/check-same-go-toolset.sh

--- a/chore-scripts/check-same-go-toolset.sh
+++ b/chore-scripts/check-same-go-toolset.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#  check-same-go-toolset.sh
+#    Check that we use the same Go Toolset image in our container build and
+#    while running our tests in CI.
+#
+set -o pipefail -o errexit -o nounset
+
+BUILDER_FILE="Dockerfile"
+ACTION_FILE=".github/workflows/unit_tests.yaml"
+
+BUILDER_IMAGE=$(sed -nre 's/^FROM\s+(.*)\s+AS builder$/\1/p' "$BUILDER_FILE")
+ACTION_IMAGE=$(sed -nre 's/^\s*image:\s+(.*)\s*$/\1/p' "$ACTION_FILE")
+
+if [[ -z $BUILDER_IMAGE ]]; then
+    echo 1>&2 "Go toolset image not found in '$BUILDER_FILE'"
+    exit 1
+fi
+
+if [[ -z $ACTION_IMAGE ]]; then
+    echo 1>&2 "Go toolset image not found in '$ACTION_FILE'"
+    exit 1
+fi
+
+if [[ "$ACTION_IMAGE" != "$BUILDER_IMAGE" ]]; then
+    echo 1>&2 "Go Toolset images in '$BUILDER_FILE' and '$ACTION_FILE' do not match"
+    echo 1>&2 "  got '$BUILDER_IMAGE' in '$BUILDER_FILE'"
+    echo 1>&2 "  got '$ACTION_IMAGE' in '$ACTION_FILE'"
+    exit 1
+fi
+
+echo "The same Go toolset image is used everywhere"
+exit 0


### PR DESCRIPTION
Add a job that ensure we use the same Go Toolset image when building our production image and when running tests in CI.