### PR TITLE
refactor(RHTAPWATCH-479): kwok image use sysv-init

### DIFF
--- a/kwok/Dockerfile
+++ b/kwok/Dockerfile
@@ -3,7 +3,8 @@ FROM registry.k8s.io/kwok/cluster:v0.4.0-k8s.v1.27.3
 ARG CLUSTER_NAME=kwok
 ENV CLUSTER_NAME=${CLUSTER_NAME}
 
-COPY --chmod=755 user-signups.sh entrypoint.sh toolchain.dev.openshift.com_usersignups.yaml ./
+COPY --chmod=755 user-signups.sh toolchain.dev.openshift.com_usersignups.yaml ./
+COPY --chmod=644 inittab /etc/inittab
 
 RUN KWOK_KUBE_APISERVER_PORT=0 kwokctl create cluster --name "$CLUSTER_NAME" || exit 1 && \
     kwokctl --name="$CLUSTER_NAME" kubectl apply -f toolchain.dev.openshift.com_usersignups.yaml && \
@@ -11,4 +12,4 @@ RUN KWOK_KUBE_APISERVER_PORT=0 kwokctl create cluster --name "$CLUSTER_NAME" || 
     rm user-signups.sh toolchain.dev.openshift.com_usersignups.yaml && \
     kwokctl stop cluster --name="$CLUSTER_NAME"
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/sbin/init"]

--- a/kwok/entrypoint.sh
+++ b/kwok/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-kwokctl start cluster --name "$CLUSTER_NAME"
-kwokctl --name "$CLUSTER_NAME" kubectl proxy --port="${KWOK_KUBE_APISERVER_PORT}" --accept-hosts='^*$' --address="0.0.0.0"

--- a/kwok/inittab
+++ b/kwok/inittab
@@ -1,0 +1,2 @@
+::wait:/usr/local/bin/kwokctl start cluster --name kwok
+::respawn:/usr/local/bin/kwokctl --name kwok kubectl proxy --port=8080 --accept-hosts='^*$' --address=0.0.0.0


### PR DESCRIPTION
Make our kwok image use the busybox version of sys-v init to launch and monitor processes. This will allow us to make it run multiple processes.