### PR TITLE
chore(RHTAPWATCH-479): add member clusters kubeconfig

### DIFF
--- a/kwok/Dockerfile
+++ b/kwok/Dockerfile
@@ -14,6 +14,9 @@ RUN KWOK_KUBE_APISERVER_PORT=0 kwokctl create cluster --name "$HOST_CLUSTER" || 
     CLUSTER_NAME="$HOST_CLUSTER" sh ./user-signups.sh && \
     kwokctl --name="$MEMBER_CLUSTER" kubectl apply -f toolchain.dev.openshift.com_usersignups.yaml && \
     kwokctl --name="$RH_CLUSTER" kubectl apply -f toolchain.dev.openshift.com_usersignups.yaml && \
+    kwokctl --name "$HOST_CLUSTER" get kubeconfig > "/$HOST_CLUSTER" && \
+    kwokctl --name "$MEMBER_CLUSTER" get kubeconfig > "/$MEMBER_CLUSTER" && \
+    kwokctl --name "$RH_CLUSTER" get kubeconfig > "/$RH_CLUSTER" && \
     kwokctl stop cluster --name="$HOST_CLUSTER" && \
     kwokctl stop cluster --name="$MEMBER_CLUSTER" && \
     kwokctl stop cluster --name="$RH_CLUSTER" && \

--- a/kwok/script.sh
+++ b/kwok/script.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Check if Podman container ID is provided as an argument
+CONTAINER_ID="$1"
+if [ -z "$CONTAINER_ID" ]; then
+    echo "Error: Please provide a container ID as an argument." >&2
+    exit 1
+fi
+
+CLUSTERS=("host" "m01" "rh01")
+KUBECONFIG_DIR="/tmp/kube/"
+KUBECONFIG=""
+
+mkdir -p "$KUBECONFIG_DIR" || { echo "Error: Failed to create directory $KUBECONFIG_DIR." >&2; exit 1; }
+
+for CLUSTER_NAME in "${CLUSTERS[@]}"; do
+    LOCAL_KUBECONFIG="${KUBECONFIG_DIR}/${CLUSTER_NAME}"
+    if podman cp "${CONTAINER_ID}:/${CLUSTER_NAME}" "$LOCAL_KUBECONFIG"; then
+        KUBECONFIG="${KUBECONFIG:+$KUBECONFIG:}$LOCAL_KUBECONFIG"
+    else
+        echo "Warning: Failed to copy kubeconfig for $CLUSTER_NAME from $CONTAINER_ID" >&2
+    fi
+done
+
+[ -n "$KUBECONFIG" ] || { echo "Error: No kubeconfig files were found." >&2; exit 1; }
+
+MERGED_KUBECONFIG="${KUBECONFIG_DIR}kubeconfig"
+kubectl config view --merge --flatten > "$MERGED_KUBECONFIG" || { echo "Error: Failed to merge kubeconfig files." >&2; exit 1; }
+
+echo "Kubeconfig merged and can be found in $MERGED_KUBECONFIG"


### PR DESCRIPTION
Changed the dockerfile so that multiple kubeconfigs are created with certs. added script to fetch those kubeconfigs and merge.


## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`podman build  -t kwok -f Dockerfile`
`podman run -d --rm  kwok`
`./script.sh <container-id>`

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key (if applicable)
- [ ] I have updated labels (if needed)
