### PR TITLE
chore: Install Python for GitLint action

### DIFF
--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -16,6 +16,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
       - name: Install Python dependencies
         run: pip install -r requirements.lock
       - name: Run gitlint on CI with pre-commit

--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,6 @@
 [general]
 contrib=contrib-title-conventional-commits,contrib-body-requires-signed-off-by
+regex-style-search=True
 
 [title-max-length]
 line-length=72
@@ -11,5 +12,5 @@ line-length=72
 
 # Bot users tends to generate invalid commits.
 [ignore-by-author-name]
-regex=(dependabot|red-hat-trusted-app-pipeline|red-hat-konflux)
+regex="^(dependabot|red-hat-trusted-app-pipeline|red-hat-konflux)$"
 ignore=all


### PR DESCRIPTION
We need to do this because using `pip` with the default Python in the Ubuntu image does not work any more.